### PR TITLE
Fix panic on invalidPayloadError.Error()

### DIFF
--- a/events/event_source.go
+++ b/events/event_source.go
@@ -16,6 +16,8 @@ var ErrUnrecognizedEventType = errors.New("unrecognized event type")
 
 var ErrSourceClosed = errors.New("source closed")
 
+var ErrNoData = errors.New("event with no data")
+
 type invalidPayloadError struct {
 	payloadType string
 	protoErr    error
@@ -130,9 +132,12 @@ func (e *eventSource) Close() error {
 
 func parseRawEvent(rawEvent sse.Event) (models.Event, error) {
 	data, err := base64.StdEncoding.DecodeString(string(rawEvent.Data))
-	if len(data) == 0 || err != nil {
+	if len(data) == 0 {
+		return nil, NewInvalidPayloadError(rawEvent.Name, ErrNoData)
+	} else if err != nil {
 		return nil, NewInvalidPayloadError(rawEvent.Name, err)
 	}
+
 	switch rawEvent.Name {
 	case models.EventTypeDesiredLRPCreated:
 		event := new(models.DesiredLRPCreatedEvent)

--- a/events/event_source_test.go
+++ b/events/event_source_test.go
@@ -325,6 +325,11 @@ var _ = Describe("EventSource", func() {
 				_, err := eventSource.Next()
 				Expect(err).To(BeAssignableToTypeOf(events.NewInvalidPayloadError(models.EventTypeDesiredLRPCreated, errors.New("whatever"))))
 			})
+
+			It("includes a useful error message", func() {
+				_, err := eventSource.Next()
+				Expect(err.Error()).To(ContainSubstring("event with no data"))
+			})
 		})
 
 		Context("when the raw event source returns an error", func() {


### PR DESCRIPTION
- Creates a new error for when SSE data has length == 0

Signed-off-by: Swetha Repakula <srepaku@us.ibm.com>