### PR TITLE
Enablement for oci-phase-1 configuration in CC

### DIFF
--- a/db/migrations/1502289152_increase_rootfs_column.go
+++ b/db/migrations/1502289152_increase_rootfs_column.go
@@ -1,0 +1,89 @@
+package migrations
+
+import (
+	"database/sql"
+	"errors"
+
+	"code.cloudfoundry.org/bbs/db/etcd"
+	"code.cloudfoundry.org/bbs/encryption"
+	"code.cloudfoundry.org/bbs/format"
+	"code.cloudfoundry.org/bbs/migration"
+	"code.cloudfoundry.org/clock"
+	"code.cloudfoundry.org/lager"
+)
+
+func init() {
+	AppendMigration(NewIncreaseRootFSColumnSize())
+}
+
+type IncreaseRootFSColumnsSize struct {
+	serializer  format.Serializer
+	storeClient etcd.StoreClient
+	clock       clock.Clock
+	rawSQLDB    *sql.DB
+	dbFlavor    string
+}
+
+func NewIncreaseRootFSColumnSize() migration.Migration {
+	return new(IncreaseRootFSColumnsSize)
+}
+
+func (e *IncreaseRootFSColumnsSize) String() string {
+	return "1502289152"
+}
+
+func (e *IncreaseRootFSColumnsSize) Version() int64 {
+	return 1502289152
+}
+
+func (e *IncreaseRootFSColumnsSize) SetStoreClient(storeClient etcd.StoreClient) {
+	e.storeClient = storeClient
+}
+
+func (e *IncreaseRootFSColumnsSize) SetCryptor(cryptor encryption.Cryptor) {
+	e.serializer = format.NewSerializer(cryptor)
+}
+
+func (e *IncreaseRootFSColumnsSize) SetRawSQLDB(db *sql.DB) {
+	e.rawSQLDB = db
+}
+
+func (e *IncreaseRootFSColumnsSize) RequiresSQL() bool         { return true }
+func (e *IncreaseRootFSColumnsSize) SetClock(c clock.Clock)    { e.clock = c }
+func (e *IncreaseRootFSColumnsSize) SetDBFlavor(flavor string) { e.dbFlavor = flavor }
+
+func (e *IncreaseRootFSColumnsSize) Up(logger lager.Logger) error {
+	logger = logger.Session("increase-rootfs-column")
+	logger.Info("starting")
+	defer logger.Info("completed")
+
+	return e.alterTables(logger, e.rawSQLDB, e.dbFlavor)
+}
+
+func (e *IncreaseRootFSColumnsSize) Down(logger lager.Logger) error {
+	return errors.New("not implemented")
+}
+
+func (e *IncreaseRootFSColumnsSize) alterTables(logger lager.Logger, db *sql.DB, flavor string) error {
+	var alterActualLRPsSQL string
+
+	if e.dbFlavor == "mysql" {
+		alterActualLRPsSQL = `ALTER TABLE desired_lrps
+	MODIFY rootfs VARCHAR(1024) NOT NULL DEFAULT ''`
+
+	} else {
+		alterActualLRPsSQL = `ALTER TABLE desired_lrps
+	ALTER rootfs TYPE VARCHAR(1024)`
+	}
+
+	logger.Info("altering-tables")
+	logger.Info("altering the table", lager.Data{"query": alterActualLRPsSQL})
+	_, err := db.Exec(alterActualLRPsSQL)
+	if err != nil {
+		logger.Error("failed-altering-tables", err)
+		return err
+	}
+	logger.Info("altered the table", lager.Data{"query": alterActualLRPsSQL})
+
+	return nil
+}

--- a/db/migrations/1502289152_increase_rootfs_column_test.go
+++ b/db/migrations/1502289152_increase_rootfs_column_test.go
@@ -1,0 +1,77 @@
+package migrations_test
+
+import (
+	"strings"
+
+	"code.cloudfoundry.org/bbs/db/migrations"
+	"code.cloudfoundry.org/bbs/db/sqldb/helpers"
+	"code.cloudfoundry.org/bbs/migration"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Increase rootfs Column Migration", func() {
+	var (
+		migration    migration.Migration
+		migrationErr error
+	)
+
+	BeforeEach(func() {
+		rawSQLDB.Exec("DROP TABLE domains;")
+		rawSQLDB.Exec("DROP TABLE tasks;")
+		rawSQLDB.Exec("DROP TABLE desired_lrps;")
+		rawSQLDB.Exec("DROP TABLE actual_lrps;")
+
+		migration = migrations.NewIncreaseRootFSColumnSize()
+	})
+
+	It("appends itself to the migration list", func() {
+		Expect(migrations.Migrations).To(ContainElement(migration))
+	})
+
+	Describe("Version", func() {
+		It("returns the timestamp from which it was created", func() {
+			Expect(migration.Version()).To(BeEquivalentTo(1502289152))
+		})
+	})
+
+	Describe("Up", func() {
+		BeforeEach(func() {
+			migration.SetRawSQLDB(rawSQLDB)
+			migration.SetDBFlavor(flavor)
+		})
+
+		JustBeforeEach(func() {
+			migrationErr = migration.Up(logger)
+		})
+
+		BeforeEach(func() {
+			createStatements := []string{
+				`CREATE TABLE desired_lrps(
+	rootfs VARCHAR(255) NOT NULL
+);`,
+			}
+			for _, st := range createStatements {
+				_, err := rawSQLDB.Exec(st)
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		It("does not error out", func() {
+			Expect(migrationErr).NotTo(HaveOccurred())
+		})
+
+		It("changes the size of the rootfs column", func() {
+			value := strings.Repeat("x", 1024)
+			query := helpers.RebindForFlavor("insert into desired_lrps(rootfs) values(?)", flavor)
+			_, err := rawSQLDB.Exec(query, value)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("Down", func() {
+		It("returns a not implemented error", func() {
+			Expect(migration.Down(logger)).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
Change rootfs column size to 1024. Diego's desired_lrp table, column roofs has width 255, which is too short to fit an OCI URI that looks like: 


`preloaded+layer:cflinuxfs2?layer=https://cloud-controller-ng.service.cf.internal:9023/internal/v4/droplets/3f53478e-d606-4380-a248-1b64ec930edd/753660e34a49c5985dd544ab184a990c1d27d3a996a13220c8a3bc8c9393e191/download&layer_path=/home/vcap&layer_digest=753660e34a49c5985dd544ab184a990c1d27d3a996a13220c8a3bc8c9393e191`

[#149234807]

Tracker: https://www.pivotaltracker.com/story/show/149234807

Signed-off-by: Tom Godkin <tgodkin@pivotal.io>
Signed-off-by: Ed King <eking@pivotal.io>
Signed-off-by: Craig Furman <cfurman@pivotal.io>