### PR TITLE
Use diego logging client in place of compatibility

### DIFF
--- a/cmd/bbs/config/config.go
+++ b/cmd/bbs/config/config.go
@@ -7,8 +7,8 @@ import (
 
 	"code.cloudfoundry.org/bbs/encryption"
 	"code.cloudfoundry.org/debugserver"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/durationjson"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/lager/lagerflags"
 	"code.cloudfoundry.org/locket"
 )
@@ -56,7 +56,7 @@ type BBSConfig struct {
 	SkipConsulLock              bool                  `json:"skip_consul_lock,omitempty"`
 	TaskCallbackWorkers         int                   `json:"task_callback_workers,omitempty"`
 	UpdateWorkers               int                   `json:"update_workers,omitempty"`
-	LoggregatorConfig           loggregator_v2.Config `json:"loggregator"`
+	LoggregatorConfig           loggingclient.Config  `json:"loggregator"`
 	debugserver.DebugServerConfig
 	encryption.EncryptionConfig
 	lagerflags.LagerConfig

--- a/cmd/bbs/config/config_test.go
+++ b/cmd/bbs/config/config_test.go
@@ -9,8 +9,8 @@ import (
 	"code.cloudfoundry.org/bbs/cmd/bbs/config"
 	"code.cloudfoundry.org/bbs/encryption"
 	"code.cloudfoundry.org/debugserver"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/durationjson"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/lager/lagerflags"
 	"code.cloudfoundry.org/locket"
 
@@ -162,7 +162,7 @@ var _ = Describe("BBSConfig", func() {
 			LagerConfig: lagerflags.LagerConfig{
 				LogLevel: "debug",
 			},
-			LoggregatorConfig: loggregator_v2.Config{
+			LoggregatorConfig: loggingclient.Config{
 				UseV2API:      true,
 				APIPort:       1234,
 				CACertPath:    "ca-path",

--- a/cmd/bbs/main.go
+++ b/cmd/bbs/main.go
@@ -37,7 +37,7 @@ import (
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/consuladapter"
 	"code.cloudfoundry.org/debugserver"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/go-loggregator/runtimeemitter"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerflags"
@@ -541,8 +541,8 @@ func initializeAuctioneerClient(logger lager.Logger, bbsConfig *config.BBSConfig
 	return auctioneer.NewClient(bbsConfig.AuctioneerAddress)
 }
 
-func initializeMetron(logger lager.Logger, bbsConfig config.BBSConfig) (loggregator_v2.IngressClient, error) {
-	client, err := loggregator_v2.NewIngressClient(bbsConfig.LoggregatorConfig)
+func initializeMetron(logger lager.Logger, bbsConfig config.BBSConfig) (loggingclient.IngressClient, error) {
+	client, err := loggingclient.NewIngressClient(bbsConfig.LoggregatorConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -570,7 +570,7 @@ func initializeEtcdDB(
 	cryptor encryption.Cryptor,
 	storeClient etcddb.StoreClient,
 	bbsConfig *config.BBSConfig,
-	metronClient loggregator_v2.IngressClient,
+	metronClient loggingclient.IngressClient,
 ) *etcddb.ETCDDB {
 	return etcddb.NewETCD(
 		format.ENCRYPTED_PROTO,

--- a/db/etcd/encryption_db_test.go
+++ b/db/etcd/encryption_db_test.go
@@ -8,7 +8,7 @@ import (
 	"code.cloudfoundry.org/bbs/encryption"
 	"code.cloudfoundry.org/bbs/format"
 	"code.cloudfoundry.org/bbs/models"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/db/etcd/etcd_db.go
+++ b/db/etcd/etcd_db.go
@@ -10,7 +10,7 @@ import (
 	"code.cloudfoundry.org/bbs/format"
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/clock"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/lager"
 	"github.com/coreos/go-etcd/etcd"
 	etcdclient "github.com/coreos/go-etcd/etcd"
@@ -90,7 +90,7 @@ type ETCDDB struct {
 	clock                     clock.Clock
 	inflightWatches           map[chan bool]bool
 	inflightWatchLock         *sync.Mutex
-	metronClient              loggregator_v2.IngressClient
+	metronClient              loggingclient.IngressClient
 }
 
 func NewETCD(
@@ -101,7 +101,7 @@ func NewETCD(
 	cryptor encryption.Cryptor,
 	storeClient StoreClient,
 	clock clock.Clock,
-	metronClient loggregator_v2.IngressClient,
+	metronClient loggingclient.IngressClient,
 ) *ETCDDB {
 	return &ETCDDB{
 		format:                    serializationFormat,

--- a/db/etcd/etcd_suite_test.go
+++ b/db/etcd/etcd_suite_test.go
@@ -12,7 +12,7 @@ import (
 	"code.cloudfoundry.org/bbs/encryption"
 	"code.cloudfoundry.org/bbs/format"
 	"code.cloudfoundry.org/clock/fakeclock"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/cloudfoundry/storeadapter/storerunner/etcdstorerunner"
 	etcdclient "github.com/coreos/go-etcd/etcd"

--- a/db/migrations/1451635200_timeouts_to_milliseconds_test.go
+++ b/db/migrations/1451635200_timeouts_to_milliseconds_test.go
@@ -12,7 +12,7 @@ import (
 	"code.cloudfoundry.org/bbs/migration"
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/bbs/models/test/model_helpers"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/lager/lagertest"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/db/sqldb/fakesqldriver/fakesqldriver_suite_test.go
+++ b/db/sqldb/fakesqldriver/fakesqldriver_suite_test.go
@@ -13,7 +13,7 @@ import (
 	"code.cloudfoundry.org/bbs/format"
 	"code.cloudfoundry.org/bbs/guidprovider/guidproviderfakes"
 	"code.cloudfoundry.org/clock/fakeclock"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/nu7hatch/gouuid"
 	. "github.com/onsi/ginkgo"

--- a/db/sqldb/lrp_convergence_test.go
+++ b/db/sqldb/lrp_convergence_test.go
@@ -13,7 +13,7 @@ import (
 	"code.cloudfoundry.org/bbs/test_helpers"
 	"code.cloudfoundry.org/lager/lagertest"
 
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"

--- a/db/sqldb/sqldb.go
+++ b/db/sqldb/sqldb.go
@@ -9,7 +9,7 @@ import (
 	"code.cloudfoundry.org/bbs/guidprovider"
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/clock"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/lager"
 )
 
@@ -25,7 +25,7 @@ type SQLDB struct {
 	encoder                format.Encoder
 	flavor                 string
 	helper                 helpers.SQLHelper
-	metronClient           loggregator_v2.IngressClient
+	metronClient           loggingclient.IngressClient
 }
 
 type RowScanner interface {
@@ -48,7 +48,7 @@ func NewSQLDB(
 	guidProvider guidprovider.GUIDProvider,
 	clock clock.Clock,
 	flavor string,
-	metronClient loggregator_v2.IngressClient,
+	metronClient loggingclient.IngressClient,
 ) *SQLDB {
 	helper := helpers.NewSQLHelper(flavor)
 	return &SQLDB{

--- a/db/sqldb/sqldb_suite_test.go
+++ b/db/sqldb/sqldb_suite_test.go
@@ -17,7 +17,7 @@ import (
 	"code.cloudfoundry.org/bbs/migration"
 	"code.cloudfoundry.org/bbs/test_helpers"
 	"code.cloudfoundry.org/clock/fakeclock"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/lager/lagertest"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/encryptor/encryptor.go
+++ b/encryptor/encryptor.go
@@ -8,7 +8,7 @@ import (
 	"code.cloudfoundry.org/bbs/encryption"
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/clock"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/lager"
 )
 
@@ -22,7 +22,7 @@ type Encryptor struct {
 	keyManager   encryption.KeyManager
 	cryptor      encryption.Cryptor
 	clock        clock.Clock
-	metronClient loggregator_v2.IngressClient
+	metronClient loggingclient.IngressClient
 }
 
 func New(
@@ -31,7 +31,7 @@ func New(
 	keyManager encryption.KeyManager,
 	cryptor encryption.Cryptor,
 	clock clock.Clock,
-	metronClient loggregator_v2.IngressClient,
+	metronClient loggingclient.IngressClient,
 ) Encryptor {
 	return Encryptor{
 		logger:       logger,

--- a/encryptor/encryptor_test.go
+++ b/encryptor/encryptor_test.go
@@ -9,7 +9,7 @@ import (
 	"code.cloudfoundry.org/bbs/encryptor"
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/clock"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/lager/lagertest"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/metrics/bbs_election_metron_notifier.go
+++ b/metrics/bbs_election_metron_notifier.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/tedsuo/ifrit"
 
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/runtimeschema/metric"
 )
@@ -16,10 +16,10 @@ const (
 
 type BBSElectionMetronNotifier struct {
 	Logger       lager.Logger
-	metronClient loggregator_v2.IngressClient
+	metronClient loggingclient.IngressClient
 }
 
-func NewBBSElectionMetronNotifier(logger lager.Logger, metronClient loggregator_v2.IngressClient) ifrit.Runner {
+func NewBBSElectionMetronNotifier(logger lager.Logger, metronClient loggingclient.IngressClient) ifrit.Runner {
 	return &BBSElectionMetronNotifier{
 		Logger:       logger,
 		metronClient: metronClient,

--- a/metrics/bbs_election_metron_notifier_test.go
+++ b/metrics/bbs_election_metron_notifier_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/bbs/metrics"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/tedsuo/ifrit"
 
@@ -15,13 +15,11 @@ import (
 
 var _ = Describe("BBSElectionMetronNotifier", func() {
 	var (
-		reportInterval   time.Duration
 		pmn              ifrit.Process
 		fakeMetronClient *mfakes.FakeIngressClient
 	)
 
 	BeforeEach(func() {
-		reportInterval = 100 * time.Millisecond
 		fakeMetronClient = new(mfakes.FakeIngressClient)
 	})
 

--- a/metrics/request_stat_metron_notifier.go
+++ b/metrics/request_stat_metron_notifier.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/clock"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/lager"
 )
 
@@ -22,10 +22,10 @@ type RequestStatMetronNotifier struct {
 	requestCount      uint64
 	maxRequestLatency time.Duration
 	lock              sync.Mutex
-	metronClient      loggregator_v2.IngressClient
+	metronClient      loggingclient.IngressClient
 }
 
-func NewRequestStatMetronNotifier(logger lager.Logger, ticker clock.Ticker, metronClient loggregator_v2.IngressClient) *RequestStatMetronNotifier {
+func NewRequestStatMetronNotifier(logger lager.Logger, ticker clock.Ticker, metronClient loggingclient.IngressClient) *RequestStatMetronNotifier {
 	return &RequestStatMetronNotifier{
 		logger:       logger,
 		ticker:       ticker,

--- a/metrics/request_stat_metron_notifier_test.go
+++ b/metrics/request_stat_metron_notifier_test.go
@@ -7,7 +7,7 @@ import (
 
 	"code.cloudfoundry.org/bbs/metrics"
 	"code.cloudfoundry.org/clock/fakeclock"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/tedsuo/ifrit"
 

--- a/migration/manager.go
+++ b/migration/manager.go
@@ -13,7 +13,7 @@ import (
 	"code.cloudfoundry.org/bbs/encryption"
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/clock"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/lager"
 )
 
@@ -32,7 +32,7 @@ type Manager struct {
 	migrationsDone chan<- struct{}
 	clock          clock.Clock
 	databaseDriver string
-	metronClient   loggregator_v2.IngressClient
+	metronClient   loggingclient.IngressClient
 }
 
 func NewManager(
@@ -46,7 +46,7 @@ func NewManager(
 	migrationsDone chan<- struct{},
 	clock clock.Clock,
 	databaseDriver string,
-	metronClient loggregator_v2.IngressClient,
+	metronClient loggingclient.IngressClient,
 ) Manager {
 	sort.Sort(migrations)
 

--- a/migration/manager_test.go
+++ b/migration/manager_test.go
@@ -12,7 +12,7 @@ import (
 	"code.cloudfoundry.org/bbs/migration/migrationfakes"
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/clock"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	. "github.com/onsi/ginkgo"


### PR DESCRIPTION
This work upgrades Diego to use go-loggregator v3.0.0. It also encapsulates Diego's use of the loggregator client behind a single interface found in `diego-logging-client` within `diego-release`.

By wrapping go-loggregator in Diego, we ensure future upgrades to go-loggregator will not require such large change sets.

This PR goes hand in hand with the following PRs:
- [diego-release](https://github.com/cloudfoundry/diego-release/pull/349)
- [auctioneer](https://github.com/cloudfoundry/auctioneer/pull/6)
- [benchmarkbbs](https://github.com/cloudfoundry/benchmarkbbs/pull/3)
- [locket](https://github.com/cloudfoundry/locket/pull/3)
- [rep](https://github.com/cloudfoundry/rep/pull/17)
- [executor](https://github.com/cloudfoundry/executor/pull/27)
- [volman](https://github.com/cloudfoundry/volman/pull/4)

[#148451433]

Signed-off-by: Jason Keene <jkeene@pivotal.io>