### PR TITLE
Add `_r0` to RemoveDesiredLRP route constant name

### DIFF
--- a/client.go
+++ b/client.go
@@ -564,7 +564,7 @@ func (c *client) RemoveDesiredLRP(logger lager.Logger, processGuid string) error
 	request := models.RemoveDesiredLRPRequest{
 		ProcessGuid: processGuid,
 	}
-	return c.doDesiredLRPLifecycleRequest(logger, RemoveDesiredLRPRoute, &request)
+	return c.doDesiredLRPLifecycleRequest(logger, RemoveDesiredLRPRoute_r0, &request)
 }
 
 func (c *client) Tasks(logger lager.Logger) ([]*models.Task, error) {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -102,7 +102,7 @@ func New(
 		bbs.DesiredLRPSchedulingInfosRoute_r0: route(middleware.RecordLatency(middleware.LogWrap(logger, accessLogger, desiredLRPHandler.DesiredLRPSchedulingInfos), emitter)),
 		bbs.DesireDesiredLRPRoute_r2:          route(middleware.RecordLatency(middleware.LogWrap(logger, accessLogger, desiredLRPHandler.DesireDesiredLRP), emitter)),
 		bbs.UpdateDesiredLRPRoute_r0:          route(middleware.RecordLatency(middleware.LogWrap(logger, accessLogger, desiredLRPHandler.UpdateDesiredLRP), emitter)),
-		bbs.RemoveDesiredLRPRoute:             route(middleware.RecordLatency(middleware.LogWrap(logger, accessLogger, desiredLRPHandler.RemoveDesiredLRP), emitter)),
+		bbs.RemoveDesiredLRPRoute_r0:          route(middleware.RecordLatency(middleware.LogWrap(logger, accessLogger, desiredLRPHandler.RemoveDesiredLRP), emitter)),
 
 		// Tasks
 		bbs.TasksRoute_r2:         route(middleware.RecordLatency(middleware.LogWrap(logger, accessLogger, taskHandler.Tasks_r2), emitter)),      // DEPRECATED

--- a/routes.go
+++ b/routes.go
@@ -41,7 +41,7 @@ const (
 	// Desire LRP Lifecycle
 	DesireDesiredLRPRoute_r2 = "DesireDesiredLRP"
 	UpdateDesiredLRPRoute_r0 = "UpdateDesireLRP"
-	RemoveDesiredLRPRoute    = "RemoveDesiredLRP"
+	RemoveDesiredLRPRoute_r0 = "RemoveDesiredLRP"
 
 	// Tasks
 	TasksRoute_r2         = "Tasks_r2"
@@ -109,7 +109,7 @@ var Routes = rata.Routes{
 	// Desire LPR Lifecycle
 	{Path: "/v1/desired_lrp/desire.r2", Method: "POST", Name: DesireDesiredLRPRoute_r2},
 	{Path: "/v1/desired_lrp/update", Method: "POST", Name: UpdateDesiredLRPRoute_r0},
-	{Path: "/v1/desired_lrp/remove", Method: "POST", Name: RemoveDesiredLRPRoute},
+	{Path: "/v1/desired_lrp/remove", Method: "POST", Name: RemoveDesiredLRPRoute_r0},
 
 	// Tasks
 	{Path: "/v1/tasks/list.r2", Method: "POST", Name: TasksRoute_r2},                  // DEPRECATED


### PR DESCRIPTION
This change ensures the constant name matches all the others. We missed this one in https://github.com/cloudfoundry/bbs/commit/bba43ff8f89ec72be93bdfe55c6c0bfce0c74aa1.

[#126557839](https://www.pivotaltracker.com/story/show/126557839)