### PR TITLE
Emit removed events when DesiredLRPHandler deletes actual lrp

### DIFF
--- a/handlers/desired_lrp_handlers.go
+++ b/handlers/desired_lrp_handlers.go
@@ -349,6 +349,9 @@ func (h *DesiredLRPHandler) stopInstancesFrom(logger lager.Logger, processGuid s
 					err = h.actualLRPDB.RemoveActualLRP(logger.Session("remove-actual"), lrp.ProcessGuid, lrp.Index, nil)
 					if err != nil {
 						logger.Error("failed-removing-lrp-instance", err)
+					} else {
+						go h.actualHub.Emit(models.NewActualLRPRemovedEvent(lrp.ToActualLRPGroup()))
+						go h.actualLRPInstanceHub.Emit(models.NewActualLRPInstanceRemovedEvent(lrp))
 					}
 				default:
 					cellPresence, err := h.serviceClient.CellById(logger, lrp.CellId)


### PR DESCRIPTION
If a crashed or unclaimed actual lrp is deleted by DesiredLRPHandler,
there was no removed event emitted, while ActualLRPLifecycleController
always emits a removed event.

DesiredLRPHandler should also emits the event to keep the consistent
behavior and make the lifecycle events complete.


How to reproduce:
1. cf push crashApp -m 1M -k 1M // push an app and make it crash
2. cf delete crashApp // delete the app when the actual lrp is in crashed state

There will be no actual_lrp_removed event for the crashed actual lrp. For the event consumers (e.g. 3rd networking plugin), it causes stale actual lrp records left in its db.