### PR TITLE
Use jackc/pgx instead of lib/pq

### DIFF
--- a/cmd/bbs/lrp_convergence_test.go
+++ b/cmd/bbs/lrp_convergence_test.go
@@ -644,7 +644,7 @@ var _ = Describe("Convergence API", func() {
 
 				BeforeEach(func() {
 					Expect(client.UpsertDomain(logger, "some-domain", 0)).To(Succeed())
-					sqlConn, err = sql.Open(sqlRunner.DriverName(), sqlRunner.ConnectionString())
+					sqlConn, err = helpers.Connect(logger, sqlRunner.DriverName(), sqlRunner.ConnectionString(), "", false)
 					Expect(err).NotTo(HaveOccurred())
 
 					_, err := sqlConn.Exec(

--- a/cmd/bbs/main.go
+++ b/cmd/bbs/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/rand"
-	"database/sql"
 	"errors"
 	"flag"
 	"fmt"
@@ -120,18 +119,18 @@ func main() {
 		logger.Fatal("no-database-configured", errors.New("no database configured"))
 	}
 
-	connectionString := helpers.AddTLSParams(logger,
+	sqlConn, err := helpers.Connect(
+		logger,
 		bbsConfig.DatabaseDriver,
 		bbsConfig.DatabaseConnectionString,
 		bbsConfig.SQLCACertFile,
 		bbsConfig.SQLEnableIdentityVerification,
 	)
-
-	sqlConn, err := sql.Open(bbsConfig.DatabaseDriver, connectionString)
 	if err != nil {
 		logger.Fatal("failed-to-open-sql", err)
 	}
 	defer sqlConn.Close()
+
 	sqlConn.SetMaxOpenConns(bbsConfig.MaxOpenDatabaseConnections)
 	sqlConn.SetMaxIdleConns(bbsConfig.MaxIdleDatabaseConnections)
 

--- a/cmd/bbs/migration_version_test.go
+++ b/cmd/bbs/migration_version_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"code.cloudfoundry.org/bbs/cmd/bbs/testrunner"
+	"code.cloudfoundry.org/bbs/db/sqldb/helpers"
 	"code.cloudfoundry.org/bbs/models"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -59,7 +60,7 @@ var _ = Describe("Migration Version", func() {
 		)
 
 		BeforeEach(func() {
-			sqlConn, err = sql.Open(sqlRunner.DriverName(), sqlRunner.ConnectionString())
+			sqlConn, err = helpers.Connect(logger, sqlRunner.DriverName(), sqlRunner.ConnectionString(), "", false)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/db/migrations/1472757022_add_placement_tags_to_desired_lrp_test.go
+++ b/db/migrations/1472757022_add_placement_tags_to_desired_lrp_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Add Placement Tags to Desired LRPs", func() {
 				),
 				"guid", "domain",
 				jsonData,
-				"log guid", 2, 1, 1, "rootfs", "routes", "volumes yo", 1, "run info",
+				"log guid", 2, 1, 1, "rootfs", "routes", "volumes yo", "1", "run info",
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/db/migrations/1474993971_encrypt_routes_test.go
+++ b/db/migrations/1474993971_encrypt_routes_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Encrypt Routes in Desired LRPs", func() {
 					flavor,
 				),
 				"guid", "domain", "",
-				"log guid", 2, 1, 1, "rootfs", routes, "volumes yo", 1, "run info",
+				"log guid", 2, 1, 1, "rootfs", routes, "volumes yo", "1", "run info",
 			)
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/db/migrations/1481761088_add_max_pid_limit_test.go
+++ b/db/migrations/1481761088_add_max_pid_limit_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Add Maximum Process limit to Desired LRPs", func() {
 					flavor,
 				),
 				"guid", "domain",
-				"log guid", 2, 1, 1, 1, "rootfs", "routes", "volumes yo", 1, "run info",
+				"log guid", 2, 1, 1, 1, "rootfs", "routes", "volumes yo", "1", "run info",
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -88,7 +88,7 @@ var _ = Describe("Add Maximum Process limit to Desired LRPs", func() {
 					flavor,
 				),
 				"guid", "domain",
-				"log guid", 2, 1, 1, "rootfs", "routes", "volumes yo", 1, "run info",
+				"log guid", 2, 1, 1, "rootfs", "routes", "volumes yo", "1", "run info",
 			)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/db/migrations/migrations_suite_test.go
+++ b/db/migrations/migrations_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"code.cloudfoundry.org/bbs/db/sqldb/helpers"
 	"code.cloudfoundry.org/bbs/encryption"
 	"code.cloudfoundry.org/bbs/migration"
 	"code.cloudfoundry.org/bbs/test_helpers"
@@ -51,7 +52,7 @@ var _ = BeforeSuite(func() {
 	// mysql must be set up on localhost as described in the CONTRIBUTING.md doc
 	// in diego-release.
 	var err error
-	rawSQLDB, err = sql.Open(sqlRunner.DriverName(), sqlRunner.ConnectionString())
+	rawSQLDB, err = helpers.Connect(logger, sqlRunner.DriverName(), sqlRunner.ConnectionString(), "", false)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(rawSQLDB.Ping()).NotTo(HaveOccurred())
 

--- a/db/sqldb/encryption_db_test.go
+++ b/db/sqldb/encryption_db_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Encryption", func() {
 				queryStr = test_helpers.ReplaceQuestionMarks(queryStr)
 			}
 			_, err = db.ExecContext(ctx, queryStr, processGuid, "fake-domain", "some-log-guid", 1, encodedRunInfo, 10, 10,
-				"some-root-fs", encodedRoutes, encodedVolumePlacement, 10)
+				"some-root-fs", encodedRoutes, encodedVolumePlacement, "10")
 			Expect(err).NotTo(HaveOccurred())
 			cryptor = makeCryptor("new", "old")
 
@@ -236,7 +236,7 @@ var _ = Describe("Encryption", func() {
 					queryStr = test_helpers.ReplaceQuestionMarks(queryStr)
 				}
 				_, err := db.ExecContext(ctx, queryStr,
-					processGuid, "fake-domain", netInfo, 0, 10, "yo")
+					processGuid, "fake-domain", netInfo, 0, "10", "yo")
 				Expect(err).NotTo(HaveOccurred())
 
 				cryptor = makeCryptor("new", "old")

--- a/db/sqldb/helpers/errors.go
+++ b/db/sqldb/helpers/errors.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/go-sql-driver/mysql"
-	"github.com/lib/pq"
+	"github.com/jackc/pgx"
 )
 
 var (
@@ -32,8 +32,8 @@ func (h *sqlHelper) ConvertSQLError(err error) error {
 		switch err.(type) {
 		case *mysql.MySQLError:
 			return h.convertMySQLError(err.(*mysql.MySQLError))
-		case *pq.Error:
-			return h.convertPostgresError(err.(*pq.Error))
+		case pgx.PgError:
+			return h.convertPostgresError(err.(pgx.PgError))
 		}
 
 		if err == sql.ErrNoRows {
@@ -59,7 +59,7 @@ func (h *sqlHelper) convertMySQLError(err *mysql.MySQLError) error {
 	}
 }
 
-func (h *sqlHelper) convertPostgresError(err *pq.Error) error {
+func (h *sqlHelper) convertPostgresError(err pgx.PgError) error {
 	switch err.Code {
 	case "22001":
 		return ErrBadRequest

--- a/db/sqldb/helpers/errors_test.go
+++ b/db/sqldb/helpers/errors_test.go
@@ -3,7 +3,7 @@ package helpers_test
 import (
 	"code.cloudfoundry.org/bbs/db/sqldb/helpers"
 	"github.com/go-sql-driver/mysql"
-	"github.com/lib/pq"
+	"github.com/jackc/pgx"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -19,7 +19,7 @@ var _ = Describe("SQL Helpers Errors", func() {
 
 	Describe("ConvertSQLError", func() {
 		It("returns a descriptive error for unknown postgres SQL errors", func() {
-			err := helper.ConvertSQLError(&pq.Error{Code: pq.ErrorCode("foo")})
+			err := helper.ConvertSQLError(pgx.PgError{Code: "foo"})
 			Expect(err).To(MatchError("sql-unknown, error code: foo, flavor: postgres"))
 		})
 

--- a/db/sqldb/sqldb_suite_test.go
+++ b/db/sqldb/sqldb_suite_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/tedsuo/ifrit"
 
-	_ "github.com/lib/pq"
+	_ "github.com/jackc/pgx/stdlib"
 
 	"testing"
 )
@@ -72,7 +72,7 @@ var _ = BeforeSuite(func() {
 
 	// mysql must be set up on localhost as described in the CONTRIBUTING.md doc
 	// in diego-release .
-	rawDB, err = sql.Open(dbDriverName, dbBaseConnectionString)
+	rawDB, err = helpers.Connect(logger, dbDriverName, dbBaseConnectionString, "", false)
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(rawDB.Ping()).NotTo(HaveOccurred())
@@ -85,7 +85,8 @@ var _ = BeforeSuite(func() {
 
 	Expect(rawDB.Close()).To(Succeed())
 
-	rawDB, err = sql.Open(dbDriverName, fmt.Sprintf("%sdiego_%d", dbBaseConnectionString, GinkgoParallelNode()))
+	connStringWithDB := fmt.Sprintf("%sdiego_%d", dbBaseConnectionString, GinkgoParallelNode())
+	rawDB, err = helpers.Connect(logger, dbDriverName, connStringWithDB, "", false)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(rawDB.Ping()).NotTo(HaveOccurred())
 
@@ -151,7 +152,7 @@ var _ = AfterSuite(func() {
 	}
 
 	Expect(rawDB.Close()).NotTo(HaveOccurred())
-	rawDB, err := sql.Open(dbDriverName, dbBaseConnectionString)
+	rawDB, err := helpers.Connect(logger, dbDriverName, dbBaseConnectionString, "", false)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(rawDB.Ping()).NotTo(HaveOccurred())
 	_, err = rawDB.Exec(fmt.Sprintf("DROP DATABASE diego_%d", GinkgoParallelNode()))

--- a/db/sqldb/version_db_test.go
+++ b/db/sqldb/version_db_test.go
@@ -3,7 +3,6 @@ package sqldb_test
 import (
 	"database/sql"
 	"encoding/json"
-	"fmt"
 
 	"code.cloudfoundry.org/bbs/db/sqldb"
 	"code.cloudfoundry.org/bbs/db/sqldb/helpers"
@@ -107,7 +106,7 @@ var _ = Describe("Version", func() {
 
 			BeforeEach(func() {
 				var err error
-				db, err = sql.Open(dbDriverName, fmt.Sprintf("%sinvalid-db", dbBaseConnectionString))
+				db, err = helpers.Connect(logger, dbDriverName, dbBaseConnectionString+"invalid-db", "", false)
 				Expect(err).NotTo(HaveOccurred())
 				helperDB := helpers.NewMonitoredDB(db, monitor.New())
 				sqlDB = sqldb.NewSQLDB(helperDB, 5, 5, cryptor, fakeGUIDProvider, fakeClock, dbFlavor, fakeMetronClient)

--- a/handlers/context_test.go
+++ b/handlers/context_test.go
@@ -45,7 +45,13 @@ var _ = Describe("Context", func() {
 		sqlProcess = ginkgomon.Invoke(sqlRunner)
 
 		var err error
-		sqlConn, err = sql.Open(sqlRunner.DriverName(), sqlRunner.ConnectionString())
+		sqlConn, err = helpers.Connect(
+			logger,
+			sqlRunner.DriverName(),
+			sqlRunner.ConnectionString(),
+			"",
+			false,
+		)
 		Expect(err).NotTo(HaveOccurred())
 
 		dbMonitor := monitor.New()


### PR DESCRIPTION
The pq library is in maintainance mode according ot the repository's
[README](https://github.com/lib/pq/tree/f3b22b2cad9e4567803b7ffd9853b8acda021438).

> This package is effectively in maintenance mode and is not actively
> developed. Small patches and features are only rarely reviewed and merged. We
> recommend using pgx which is actively maintained.