### PR TITLE
Ensure claim LRP request for suspect LRP is ignored

### DIFF
--- a/controllers/actual_lrp_lifecycle_controller.go
+++ b/controllers/actual_lrp_lifecycle_controller.go
@@ -78,6 +78,17 @@ func (h *ActualLRPLifecycleController) ClaimActualLRP(ctx context.Context, logge
 		return err
 	}
 
+	lrp := lookupLRPInSlice(lrps, actualLRPInstanceKey)
+	if lrp != nil && lrp.Presence == models.ActualLRP_Suspect {
+		logger.Info("ignored-claim-request-from-suspect", lager.Data{
+			"process_guid":  processGUID,
+			"index":         index,
+			"instance_guid": actualLRPInstanceKey,
+			"state":         lrp.State,
+		})
+		return nil
+	}
+
 	before, after, err := h.db.ClaimActualLRP(ctx, logger, processGUID, index, actualLRPInstanceKey)
 	if err != nil {
 		return err


### PR DESCRIPTION
When a cell loses presence and tries to claim an LRP that it owns, we
want to ignore the request and let convergence etc. properly take action
to right the ship. If we let the suspect cell claim a suspect LRP, it causes any
replacement UNCLAIMED ORDINARY LRP (which has the same key) to be updated
and transition to CLAIMED ORDINARY (and be claimed by the suspect cell). This causes there to be 2 LRPs with the same key and instance key, but
different presences. When a subsequent Start request comes in from the suspect cell for the
suspect LRP, it is not ignored as intended, but instead the replacement LRP
that was erroneously moved to CLAIMED is transitioned to RUNNING. This then causes the CLAIMED SUSPECT LRP to be removed, generating an unexpected actual_lrp_removed event