### PR TITLE
Make `cfdot actual-lrps` consistent

### DIFF
--- a/models/actual_lrp.pb.go
+++ b/models/actual_lrp.pb.go
@@ -5,15 +5,16 @@ package models
 
 import (
 	fmt "fmt"
-	_ "github.com/gogo/protobuf/gogoproto"
-	proto "github.com/gogo/protobuf/proto"
-	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 	io "io"
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
 	strconv "strconv"
 	strings "strings"
+
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -131,7 +132,7 @@ type PortMapping struct {
 	ContainerPort         uint32 `protobuf:"varint,1,opt,name=container_port,json=containerPort,proto3" json:"container_port"`
 	HostPort              uint32 `protobuf:"varint,2,opt,name=host_port,json=hostPort,proto3" json:"host_port"`
 	ContainerTlsProxyPort uint32 `protobuf:"varint,3,opt,name=container_tls_proxy_port,json=containerTlsProxyPort,proto3" json:"container_tls_proxy_port,omitempty"`
-	HostTlsProxyPort      uint32 `protobuf:"varint,4,opt,name=host_tls_proxy_port,json=hostTlsProxyPort,proto3" json:"host_tls_proxy_port,omitempty"`
+	HostTlsProxyPort      uint32 `protobuf:"varint,4,opt,name=host_tls_proxy_port,json=hostTlsProxyPort,proto3" json:"host_tls_proxy_port"`
 }
 
 func (m *PortMapping) Reset()      { *m = PortMapping{} }


### PR DESCRIPTION
### What is this change about?

`cfdot` is not reporting empty `host_tls_proxy_port` when C2c is utilized


1.  Deploy an app on CF with c2c networking enabled
2.  ssh into the diego cell that the app is running on
3. Run `cfdot actual-lrps`

In the port section, each array entry should have 4 attributes. If there's no correpsonding port, it should list `0` as the port.
```
 "ports": [
    {
      "container_port": 8080,
      "host_port": 61004,
      "container_tls_proxy_port": 61001,
      "host_tls_proxy_port": 61006
    },
    {
      "container_port": 8080,
      "host_port": 61004,
      "container_tls_proxy_port": 61443,
      "host_tls_proxy_port": 0
    },
    {
      "container_port": 2222,
      "host_port": 61005,
      "container_tls_proxy_port": 61002,
      "host_tls_proxy_port": 61007
    }
  ],
```

For the C2CTLS port (61443), there is no entry for `host_tls_proxy_port`. This should be set to 0 in all cases (regardless of whether the values of the `containers.proxy.enable_unproxied_port_mappings` and `containers.proxy.require_and_verify_client_certificates` properties are set)
```
{
  "process_guid": "4a295375-84d5-4017-8e14-97cc08fef7e6-f257d4b3-e810-4ad9-bfbe-f493dcddddb0",
  "index": 0,
  "domain": "cf-apps",
  "instance_guid": "6f042458-693c-456a-6fa6-ed96",
  "cell_id": "e0c33815-b521-4e83-bc43-a8fb41d29ea7",
  "address": "10.0.1.14",
  "ports": [
    {
      "container_port": 8080,
      "host_port": 61000,
      "container_tls_proxy_port": 61001,
      "host_tls_proxy_port": 61002
    },
    {
      "container_port": 8080,
      "host_port": 61000,
      "container_tls_proxy_port": 61443
    },
    {
      "container_port": 2222,
      "host_port": 61001,
      "container_tls_proxy_port": 61002,
      "host_tls_proxy_port": 61003
    }
  ],
```

### What problem it is trying to solve?

This change will report `host_tls_proxy_port` when it is empty as well as populated


### How should this change be described in diego-release release notes?

The bbs now correctly reports empty port assignments when using C2C networking

### Please provide any contextual information.

[Tracker story for private repo183842469](https://www.pivotaltracker.com/n/projects/2477027/stories/183842469)

