### PR TITLE
Add distributed tracing

### DIFF
--- a/handlers/actual_lrp_handlers.go
+++ b/handlers/actual_lrp_handlers.go
@@ -22,7 +22,7 @@ func NewActualLRPHandler(db db.ActualLRPDB, exitChan chan<- struct{}) *ActualLRP
 
 func (h *ActualLRPHandler) ActualLRPs(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("actual-lrps")
+	logger = logger.Session("actual-lrps").WithTraceInfo(req)
 	logger.Debug("starting")
 	defer logger.Debug("complete")
 
@@ -49,7 +49,7 @@ func (h *ActualLRPHandler) ActualLRPs(logger lager.Logger, w http.ResponseWriter
 // DEPRECATED
 func (h *ActualLRPHandler) ActualLRPGroups(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("actual-lrp-groups")
+	logger = logger.Session("actual-lrp-groups").WithTraceInfo(req)
 
 	request := &models.ActualLRPGroupsRequest{}
 	response := &models.ActualLRPGroupsResponse{}
@@ -74,7 +74,7 @@ func (h *ActualLRPHandler) ActualLRPGroups(logger lager.Logger, w http.ResponseW
 // DEPRECATED
 func (h *ActualLRPHandler) ActualLRPGroupsByProcessGuid(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("actual-lrp-groups-by-process-guid")
+	logger = logger.Session("actual-lrp-groups-by-process-guid").WithTraceInfo(req)
 
 	request := &models.ActualLRPGroupsByProcessGuidRequest{}
 	response := &models.ActualLRPGroupsResponse{}
@@ -98,7 +98,7 @@ func (h *ActualLRPHandler) ActualLRPGroupsByProcessGuid(logger lager.Logger, w h
 // DEPRECATED
 func (h *ActualLRPHandler) ActualLRPGroupByProcessGuidAndIndex(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("actual-lrp-group-by-process-guid-and-index")
+	logger = logger.Session("actual-lrp-group-by-process-guid-and-index").WithTraceInfo(req)
 
 	request := &models.ActualLRPGroupByProcessGuidAndIndexRequest{}
 	response := &models.ActualLRPGroupResponse{}

--- a/handlers/actual_lrp_handlers_test.go
+++ b/handlers/actual_lrp_handlers_test.go
@@ -1,12 +1,15 @@
 package handlers_test
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 
 	"code.cloudfoundry.org/bbs/db/dbfakes"
 	"code.cloudfoundry.org/bbs/handlers"
 	"code.cloudfoundry.org/bbs/models"
+	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -24,6 +27,9 @@ var _ = Describe("ActualLRP Handlers", func() {
 		actualLRP1     models.ActualLRP
 		actualLRP2     models.ActualLRP
 		evacuatingLRP2 models.ActualLRP
+
+		requestIdHeader   string
+		b3RequestIdHeader string
 	)
 
 	BeforeEach(func() {
@@ -68,6 +74,8 @@ var _ = Describe("ActualLRP Handlers", func() {
 		logger = lagertest.NewTestLogger("test")
 		responseRecorder = httptest.NewRecorder()
 		exitCh = make(chan struct{}, 1)
+		requestIdHeader = "f256f938-9e14-4abd-974f-63c6138f1cca"
+		b3RequestIdHeader = fmt.Sprintf(`"trace-id":"%s"`, strings.Replace(requestIdHeader, "-", "", -1))
 		handler = handlers.NewActualLRPHandler(fakeActualLRPDB, exitCh)
 	})
 
@@ -80,6 +88,7 @@ var _ = Describe("ActualLRP Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.ActualLRPs(logger, responseRecorder, request)
 		})
 
@@ -228,6 +237,7 @@ var _ = Describe("ActualLRP Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -257,6 +267,7 @@ var _ = Describe("ActualLRP Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.ActualLRPGroups(logger, responseRecorder, request)
 		})
 
@@ -357,6 +368,7 @@ var _ = Describe("ActualLRP Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -391,6 +403,7 @@ var _ = Describe("ActualLRP Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.ActualLRPGroupsByProcessGuid(logger, responseRecorder, request)
 		})
 
@@ -455,6 +468,7 @@ var _ = Describe("ActualLRP Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -493,6 +507,7 @@ var _ = Describe("ActualLRP Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.ActualLRPGroupByProcessGuidAndIndex(logger, responseRecorder, request)
 		})
 
@@ -564,6 +579,7 @@ var _ = Describe("ActualLRP Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})

--- a/handlers/actual_lrp_lifecycle_handler.go
+++ b/handlers/actual_lrp_lifecycle_handler.go
@@ -37,7 +37,7 @@ func NewActualLRPLifecycleHandler(
 
 func (h *ActualLRPLifecycleHandler) ClaimActualLRP(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("claim-actual-lrp")
+	logger = logger.Session("claim-actual-lrp").WithTraceInfo(req)
 	logger.Debug("starting")
 	defer logger.Debug("complete")
 
@@ -57,7 +57,7 @@ func (h *ActualLRPLifecycleHandler) ClaimActualLRP(logger lager.Logger, w http.R
 }
 
 func (h *ActualLRPLifecycleHandler) StartActualLRP(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
-	logger = logger.Session("start-actual-lrp")
+	logger = logger.Session("start-actual-lrp").WithTraceInfo(req)
 	logger.Debug("starting")
 	defer logger.Debug("complete")
 
@@ -78,7 +78,7 @@ func (h *ActualLRPLifecycleHandler) StartActualLRP(logger lager.Logger, w http.R
 }
 
 func (h *ActualLRPLifecycleHandler) StartActualLRP_r0(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
-	logger = logger.Session("start-actual-lrp")
+	logger = logger.Session("start-actual-lrp").WithTraceInfo(req)
 	logger.Debug("starting")
 	defer logger.Debug("complete")
 
@@ -99,7 +99,7 @@ func (h *ActualLRPLifecycleHandler) StartActualLRP_r0(logger lager.Logger, w htt
 }
 
 func (h *ActualLRPLifecycleHandler) CrashActualLRP(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
-	logger = logger.Session("crash-actual-lrp")
+	logger = logger.Session("crash-actual-lrp").WithTraceInfo(req)
 	logger.Debug("starting")
 	defer logger.Debug("complete")
 
@@ -123,7 +123,7 @@ func (h *ActualLRPLifecycleHandler) CrashActualLRP(logger lager.Logger, w http.R
 
 func (h *ActualLRPLifecycleHandler) FailActualLRP(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("fail-actual-lrp")
+	logger = logger.Session("fail-actual-lrp").WithTraceInfo(req)
 	logger.Debug("starting")
 	defer logger.Debug("complete")
 
@@ -145,7 +145,7 @@ func (h *ActualLRPLifecycleHandler) FailActualLRP(logger lager.Logger, w http.Re
 
 func (h *ActualLRPLifecycleHandler) RemoveActualLRP(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("remove-actual-lrp")
+	logger = logger.Session("remove-actual-lrp").WithTraceInfo(req)
 	logger.Debug("starting")
 	defer logger.Debug("complete")
 
@@ -166,7 +166,7 @@ func (h *ActualLRPLifecycleHandler) RemoveActualLRP(logger lager.Logger, w http.
 }
 
 func (h *ActualLRPLifecycleHandler) RetireActualLRP(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
-	logger = logger.Session("retire-actual-lrp")
+	logger = logger.Session("retire-actual-lrp").WithTraceInfo(req)
 	logger.Debug("starting")
 	defer logger.Debug("complete")
 	request := &models.RetireActualLRPRequest{}

--- a/handlers/actual_lrp_lifecycle_handler_test.go
+++ b/handlers/actual_lrp_lifecycle_handler_test.go
@@ -2,13 +2,16 @@ package handlers_test
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 
 	"code.cloudfoundry.org/bbs/handlers"
 	"code.cloudfoundry.org/bbs/handlers/fake_controllers"
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/bbs/serviceclient/serviceclientfakes"
+	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	"code.cloudfoundry.org/rep/repfakes"
 	. "github.com/onsi/ginkgo/v2"
@@ -23,6 +26,9 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 		handler          *handlers.ActualLRPLifecycleHandler
 		fakeController   *fake_controllers.FakeActualLRPLifecycleController
 		exitCh           chan struct{}
+
+		requestIdHeader   string
+		b3RequestIdHeader string
 	)
 
 	BeforeEach(func() {
@@ -35,6 +41,8 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 		fakeRepClientFactory.CreateClientReturns(fakeRepClient, nil)
 
 		exitCh = make(chan struct{}, 1)
+		requestIdHeader = "b67c32c0-1666-49dc-97c1-274332e6b706"
+		b3RequestIdHeader = fmt.Sprintf(`"trace-id":"%s"`, strings.Replace(requestIdHeader, "-", "", -1))
 		fakeController = &fake_controllers.FakeActualLRPLifecycleController{}
 		handler = handlers.NewActualLRPLifecycleHandler(fakeController, exitCh)
 	})
@@ -62,6 +70,7 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.ClaimActualLRP(logger, responseRecorder, request)
 		})
 
@@ -95,6 +104,7 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -153,6 +163,7 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.StartActualLRP(logger, responseRecorder, request)
 		})
 
@@ -188,6 +199,7 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -208,6 +220,102 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 		})
 	})
 
+	Describe("StartActualLRP_r0", func() {
+		var (
+			processGuid = "process-guid"
+			index       = int32(1)
+
+			key            models.ActualLRPKey
+			instanceKey    models.ActualLRPInstanceKey
+			netInfo        models.ActualLRPNetInfo
+			internalRoutes []*models.ActualLRPInternalRoute
+			metricTags     map[string]string
+
+			requestBody interface{}
+		)
+
+		BeforeEach(func() {
+			key = models.NewActualLRPKey(
+				processGuid,
+				index,
+				"domain-0",
+			)
+			instanceKey = models.NewActualLRPInstanceKey(
+				"instance-guid-0",
+				"cell-id-0",
+			)
+			netInfo = models.NewActualLRPNetInfo("1.1.1.1", "2.2.2.2", models.ActualLRPNetInfo_PreferredAddressUnknown, models.NewPortMapping(10, 20))
+			internalRoutes = []*models.ActualLRPInternalRoute{{Hostname: "some-internal-route.apps.internal"}}
+			metricTags = map[string]string{"app_name": "some-app-name"}
+			requestBody = &models.StartActualLRPRequest{
+				ActualLrpKey:            &key,
+				ActualLrpInstanceKey:    &instanceKey,
+				ActualLrpNetInfo:        &netInfo,
+				ActualLrpInternalRoutes: internalRoutes,
+				MetricTags:              metricTags,
+			}
+		})
+
+		JustBeforeEach(func() {
+			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
+			handler.StartActualLRP_r0(logger, responseRecorder, request)
+		})
+
+		It("calls the controller", func() {
+			Expect(fakeController.StartActualLRPCallCount()).To(Equal(1))
+			_, _, actualKey, actualInstanceKey, actualNetInfo, actualInternalRoutes, actualMetricTags := fakeController.StartActualLRPArgsForCall(0)
+			Expect(actualKey).To(Equal(&key))
+			Expect(actualInstanceKey).To(Equal(&instanceKey))
+			Expect(actualNetInfo).To(Equal(&netInfo))
+			Expect(len(actualInternalRoutes)).To(Equal(0))
+			Expect(actualMetricTags).To(BeNil())
+		})
+
+		Context("when starting the actual lrp in the DB succeeds", func() {
+			BeforeEach(func() {
+				fakeController.StartActualLRPReturns(nil)
+			})
+
+			It("responds with no error", func() {
+				Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+				Eventually(logger).Should(gbytes.Say("starting"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
+				response := &models.ActualLRPLifecycleResponse{}
+				err := response.Unmarshal(responseRecorder.Body.Bytes())
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(response.Error).To(BeNil())
+			})
+		})
+
+		Context("when an unrecoverable error is returned", func() {
+			BeforeEach(func() {
+				fakeController.StartActualLRPReturns(models.NewUnrecoverableError(nil))
+			})
+
+			It("logs and writes to the exit channel", func() {
+				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
+				Eventually(exitCh).Should(Receive())
+			})
+		})
+
+		Context("when a recoverable error is returned", func() {
+			BeforeEach(func() {
+				fakeController.StartActualLRPReturns(models.ErrUnknownError)
+			})
+
+			It("responds with an error", func() {
+				Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+				response := &models.ActualLRPLifecycleResponse{}
+				err := response.Unmarshal(responseRecorder.Body.Bytes())
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(response.Error).To(Equal(models.ErrUnknownError))
+			})
+		})
+	})
 	Describe("CrashActualLRP", func() {
 		var (
 			processGuid  = "process-guid"
@@ -239,6 +347,7 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.CrashActualLRP(logger, responseRecorder, request)
 		})
 
@@ -272,6 +381,7 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -318,6 +428,7 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 
 		JustBeforeEach(func() {
 			request = newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.RetireActualLRP(logger, responseRecorder, request)
 
 			response = &models.ActualLRPLifecycleResponse{}
@@ -338,6 +449,7 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -380,6 +492,7 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 
 		JustBeforeEach(func() {
 			request = newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.FailActualLRP(logger, responseRecorder, request)
 		})
 
@@ -413,6 +526,7 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -458,6 +572,7 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.RemoveActualLRP(logger, responseRecorder, request)
 		})
 
@@ -491,6 +606,7 @@ var _ = Describe("ActualLRP Lifecycle Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})

--- a/handlers/cell_handlers.go
+++ b/handlers/cell_handlers.go
@@ -22,7 +22,7 @@ func NewCellHandler(serviceClient serviceclient.ServiceClient, exitChan chan<- s
 
 func (h *CellHandler) Cells(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("cells")
+	logger = logger.Session("cells").WithTraceInfo(req)
 	response := &models.CellsResponse{}
 	cellSet, err := h.serviceClient.Cells(logger)
 	cells := []*models.CellPresence{}

--- a/handlers/desired_lrp_handlers.go
+++ b/handlers/desired_lrp_handlers.go
@@ -58,7 +58,7 @@ func NewDesiredLRPHandler(
 
 func (h *DesiredLRPHandler) commonDesiredLRPs(logger lager.Logger, targetVersion format.Version, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("desired-lrps")
+	logger = logger.Session("desired-lrps").WithTraceInfo(req)
 
 	request := &models.DesiredLRPsRequest{}
 	response := &models.DesiredLRPsResponse{}
@@ -95,7 +95,7 @@ func (h *DesiredLRPHandler) DesiredLRPs_r2(logger lager.Logger, w http.ResponseW
 
 func (h *DesiredLRPHandler) commonDesiredLRPByProcessGuid(logger lager.Logger, targetVersion format.Version, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("desired-lrp-by-process-guid")
+	logger = logger.Session("desired-lrp-by-process-guid").WithTraceInfo(req)
 
 	request := &models.DesiredLRPByProcessGuidRequest{}
 	response := &models.DesiredLRPResponse{}
@@ -126,7 +126,7 @@ func (h *DesiredLRPHandler) DesiredLRPByProcessGuid_r2(logger lager.Logger, w ht
 
 func (h *DesiredLRPHandler) DesiredLRPSchedulingInfos(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("desired-lrp-scheduling-infos")
+	logger = logger.Session("desired-lrp-scheduling-infos").WithTraceInfo(req)
 	logger.Debug("starting")
 	defer logger.Debug("complete")
 
@@ -148,7 +148,7 @@ func (h *DesiredLRPHandler) DesiredLRPSchedulingInfos(logger lager.Logger, w htt
 }
 
 func (h *DesiredLRPHandler) DesireDesiredLRP(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
-	logger = logger.Session("desire-lrp")
+	logger = logger.Session("desire-lrp").WithTraceInfo(req)
 
 	request := &models.DesireLRPRequest{}
 	response := &models.DesiredLRPLifecycleResponse{}
@@ -182,7 +182,7 @@ func (h *DesiredLRPHandler) DesireDesiredLRP(logger lager.Logger, w http.Respons
 }
 
 func (h *DesiredLRPHandler) UpdateDesiredLRP(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
-	logger = logger.Session("update-desired-lrp")
+	logger = logger.Session("update-desired-lrp").WithTraceInfo(req)
 
 	request := &models.UpdateDesiredLRPRequest{}
 	response := &models.DesiredLRPLifecycleResponse{}
@@ -244,7 +244,7 @@ func (h *DesiredLRPHandler) UpdateDesiredLRP(logger lager.Logger, w http.Respons
 }
 
 func (h *DesiredLRPHandler) RemoveDesiredLRP(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
-	logger = logger.Session("remove-desired-lrp")
+	logger = logger.Session("remove-desired-lrp").WithTraceInfo(req)
 
 	request := &models.RemoveDesiredLRPRequest{}
 	response := &models.DesiredLRPLifecycleResponse{}

--- a/handlers/desired_lrp_handlers_test.go
+++ b/handlers/desired_lrp_handlers_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 
 	"code.cloudfoundry.org/auctioneer"
 	"code.cloudfoundry.org/auctioneer/auctioneerfakes"
@@ -40,6 +42,9 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 		desiredLRP1 models.DesiredLRP
 		desiredLRP2 models.DesiredLRP
+
+		requestIdHeader   string
+		b3RequestIdHeader string
 	)
 
 	BeforeEach(func() {
@@ -55,6 +60,8 @@ var _ = Describe("DesiredLRP Handlers", func() {
 		actualLRPInstanceHub = new(eventfakes.FakeHub)
 		Expect(err).NotTo(HaveOccurred())
 		exitCh = make(chan struct{}, 1)
+		requestIdHeader = "25f23d6a-f46d-460e-7135-7ddc0759a198"
+		b3RequestIdHeader = fmt.Sprintf(`"trace-id":"%s"`, strings.Replace(requestIdHeader, "-", "", -1))
 		handler = handlers.NewDesiredLRPHandler(
 			5,
 			fakeDesiredLRPDB,
@@ -80,6 +87,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.DesiredLRPs_r2(logger, responseRecorder, request)
 		})
 
@@ -216,6 +224,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -247,6 +256,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.DesiredLRPs(logger, responseRecorder, request)
 		})
 
@@ -350,6 +360,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -385,6 +396,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.DesiredLRPByProcessGuid_r2(logger, responseRecorder, request)
 		})
 
@@ -482,6 +494,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -517,6 +530,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.DesiredLRPByProcessGuid(logger, responseRecorder, request)
 		})
 
@@ -591,6 +605,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -626,6 +641,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.DesiredLRPSchedulingInfos(logger, responseRecorder, request)
 		})
 
@@ -703,6 +719,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -740,6 +757,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.DesireDesiredLRP(logger, responseRecorder, request)
 		})
 
@@ -902,6 +920,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -955,6 +974,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.UpdateDesiredLRP(logger, responseRecorder, request)
 		})
 
@@ -1094,6 +1114,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 						It("continues stopping the rest of the lrps and logs", func() {
 							Expect(fakeRepClient.StopLRPInstanceCallCount()).To(Equal(1))
 							Expect(logger).To(gbytes.Say("failed-fetching-cell-presence"))
+							Expect(logger).Should(gbytes.Say(b3RequestIdHeader))
 						})
 					})
 
@@ -1111,6 +1132,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 						It("continues stopping the rest of the lrps and logs", func() {
 							Expect(fakeRepClient.StopLRPInstanceCallCount()).To(Equal(2))
 							Expect(logger).To(gbytes.Say("failed-stopping-lrp-instance"))
+							Expect(logger).Should(gbytes.Say(b3RequestIdHeader))
 						})
 					})
 				})
@@ -1489,6 +1511,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -1526,6 +1549,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.RemoveDesiredLRP(logger, responseRecorder, request)
 		})
 
@@ -1691,6 +1715,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 						Expect(response.Error).To(BeNil())
 						Expect(logger).To(gbytes.Say("failed-fetching-actual-lrps"))
+						Expect(logger).Should(gbytes.Say(b3RequestIdHeader))
 					})
 				})
 			})
@@ -1703,6 +1728,7 @@ var _ = Describe("DesiredLRP Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})

--- a/handlers/domain_handlers.go
+++ b/handlers/domain_handlers.go
@@ -28,7 +28,7 @@ func NewDomainHandler(db db.DomainDB, exitChan chan<- struct{}) *DomainHandler {
 
 func (h *DomainHandler) Domains(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("domains")
+	logger = logger.Session("domains").WithTraceInfo(req)
 	response := &models.DomainsResponse{}
 	response.Domains, err = h.db.FreshDomains(req.Context(), logger)
 	response.Error = models.ConvertError(err)
@@ -38,7 +38,7 @@ func (h *DomainHandler) Domains(logger lager.Logger, w http.ResponseWriter, req 
 
 func (h *DomainHandler) Upsert(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("upsert")
+	logger = logger.Session("upsert").WithTraceInfo(req)
 
 	request := &models.UpsertDomainRequest{}
 	response := &models.UpsertDomainResponse{}

--- a/handlers/events_handlers_r0.go
+++ b/handlers/events_handlers_r0.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (h *LRPGroupEventsHandler) commonSubscribe(logger lager.Logger, w http.ResponseWriter, req *http.Request, target format.Version) {
-	logger = logger.Session("subscribe-r0")
+	logger = logger.Session("subscribe-r0").WithTraceInfo(req)
 
 	request := &models.EventsByCellId{}
 	err := parseRequest(logger, req, request)
@@ -84,7 +84,7 @@ func (h *LRPGroupEventsHandler) Subscribe_r1(logger lager.Logger, w http.Respons
 }
 
 func (h *LRPInstanceEventHandler) commonSubscribe(logger lager.Logger, w http.ResponseWriter, req *http.Request, target format.Version) {
-	logger = logger.Session("subscribe-r0")
+	logger = logger.Session("subscribe-r0").WithTraceInfo(req)
 
 	request := &models.EventsByCellId{}
 	err := parseRequest(logger, req, request)
@@ -157,7 +157,7 @@ func (h *LRPInstanceEventHandler) Subscribe_r1(logger lager.Logger, w http.Respo
 }
 
 func (h *TaskEventHandler) commonSubscribe(logger lager.Logger, w http.ResponseWriter, req *http.Request, target format.Version) {
-	logger = logger.Session("tasks-subscribe-r0")
+	logger = logger.Session("tasks-subscribe-r0").WithTraceInfo(req)
 	logger.Info("subscribed-to-tasks-event-stream")
 
 	taskSource, err := h.taskHub.Subscribe()

--- a/handlers/task_handlers.go
+++ b/handlers/task_handlers.go
@@ -43,7 +43,7 @@ func NewTaskHandler(
 
 func (h *TaskHandler) commonTasks(logger lager.Logger, targetVersion format.Version, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("tasks")
+	logger = logger.Session("tasks").WithTraceInfo(req)
 
 	request := &models.TasksRequest{}
 	response := &models.TasksResponse{}
@@ -78,7 +78,7 @@ func (h *TaskHandler) Tasks(logger lager.Logger, w http.ResponseWriter, req *htt
 
 func (h *TaskHandler) commonTaskByGuid(logger lager.Logger, targetVersion format.Version, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("task-by-guid")
+	logger = logger.Session("task-by-guid").WithTraceInfo(req)
 
 	request := &models.TaskByGuidRequest{}
 	response := &models.TaskResponse{}
@@ -113,7 +113,7 @@ func (h *TaskHandler) TaskByGuid(logger lager.Logger, w http.ResponseWriter, req
 
 func (h *TaskHandler) DesireTask(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("desire-task")
+	logger = logger.Session("desire-task").WithTraceInfo(req)
 
 	request := &models.DesireTaskRequest{}
 	response := &models.TaskLifecycleResponse{}
@@ -134,7 +134,7 @@ func (h *TaskHandler) DesireTask(logger lager.Logger, w http.ResponseWriter, req
 
 func (h *TaskHandler) StartTask(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("start-task")
+	logger = logger.Session("start-task").WithTraceInfo(req)
 
 	request := &models.StartTaskRequest{}
 	response := &models.StartTaskResponse{}
@@ -154,7 +154,7 @@ func (h *TaskHandler) StartTask(logger lager.Logger, w http.ResponseWriter, req 
 }
 
 func (h *TaskHandler) CancelTask(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
-	logger = logger.Session("cancel-task")
+	logger = logger.Session("cancel-task").WithTraceInfo(req)
 
 	request := &models.TaskGuidRequest{}
 	response := &models.TaskLifecycleResponse{}
@@ -175,7 +175,7 @@ func (h *TaskHandler) CancelTask(logger lager.Logger, w http.ResponseWriter, req
 
 func (h *TaskHandler) FailTask(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("fail-task")
+	logger = logger.Session("fail-task").WithTraceInfo(req)
 
 	request := &models.FailTaskRequest{}
 	response := &models.TaskLifecycleResponse{}
@@ -196,7 +196,7 @@ func (h *TaskHandler) FailTask(logger lager.Logger, w http.ResponseWriter, req *
 
 func (h *TaskHandler) RejectTask(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("reject-task")
+	logger = logger.Session("reject-task").WithTraceInfo(req)
 
 	request := &models.RejectTaskRequest{}
 	response := &models.TaskLifecycleResponse{}
@@ -217,7 +217,7 @@ func (h *TaskHandler) RejectTask(logger lager.Logger, w http.ResponseWriter, req
 
 func (h *TaskHandler) CompleteTask(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("complete-task")
+	logger = logger.Session("complete-task").WithTraceInfo(req)
 
 	request := &models.CompleteTaskRequest{}
 	response := &models.TaskLifecycleResponse{}
@@ -238,7 +238,7 @@ func (h *TaskHandler) CompleteTask(logger lager.Logger, w http.ResponseWriter, r
 
 func (h *TaskHandler) ResolvingTask(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("resolving-task")
+	logger = logger.Session("resolving-task").WithTraceInfo(req)
 
 	request := &models.TaskGuidRequest{}
 	response := &models.TaskLifecycleResponse{}
@@ -259,7 +259,7 @@ func (h *TaskHandler) ResolvingTask(logger lager.Logger, w http.ResponseWriter, 
 
 func (h *TaskHandler) DeleteTask(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	var err error
-	logger = logger.Session("delete-task")
+	logger = logger.Session("delete-task").WithTraceInfo(req)
 
 	request := &models.TaskGuidRequest{}
 	response := &models.TaskLifecycleResponse{}

--- a/handlers/task_handlers_test.go
+++ b/handlers/task_handlers_test.go
@@ -2,8 +2,10 @@ package handlers_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 
 	"code.cloudfoundry.org/bbs/format"
 	"code.cloudfoundry.org/bbs/handlers"
@@ -11,6 +13,7 @@ import (
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/bbs/models/test/model_helpers"
 	. "code.cloudfoundry.org/bbs/test_helpers"
+	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,13 +26,14 @@ var _ = Describe("Task Handlers", func() {
 		controller *fake_controllers.FakeTaskController
 
 		responseRecorder *httptest.ResponseRecorder
-
-		handler *handlers.TaskHandler
-		exitCh  chan struct{}
+		handler          *handlers.TaskHandler
+		exitCh           chan struct{}
 
 		requestBody interface{}
+		request     *http.Request
 
-		request *http.Request
+		requestIdHeader   string
+		b3RequestIdHeader string
 	)
 
 	BeforeEach(func() {
@@ -38,6 +42,9 @@ var _ = Describe("Task Handlers", func() {
 		exitCh = make(chan struct{}, 1)
 		controller = &fake_controllers.FakeTaskController{}
 		handler = handlers.NewTaskHandler(controller, exitCh)
+
+		requestIdHeader = "e52a3684-8d05-4905-bfeb-f1d59d92eb1d"
+		b3RequestIdHeader = fmt.Sprintf(`"trace-id":"%s"`, strings.Replace(requestIdHeader, "-", "", -1))
 	})
 
 	Describe("Tasks_r2", func() {
@@ -65,6 +72,7 @@ var _ = Describe("Task Handlers", func() {
 				CellId: cellId,
 			}
 			request = newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.Tasks_r2(logger, responseRecorder, request)
 		})
 
@@ -156,6 +164,7 @@ var _ = Describe("Task Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -196,6 +205,7 @@ var _ = Describe("Task Handlers", func() {
 				CellId: cellId,
 			}
 			request = newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.Tasks(logger, responseRecorder, request)
 		})
 
@@ -260,6 +270,7 @@ var _ = Describe("Task Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -291,6 +302,7 @@ var _ = Describe("Task Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.TaskByGuid_r2(logger, responseRecorder, request)
 		})
 
@@ -374,6 +386,7 @@ var _ = Describe("Task Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -405,6 +418,7 @@ var _ = Describe("Task Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.TaskByGuid(logger, responseRecorder, request)
 		})
 
@@ -463,6 +477,7 @@ var _ = Describe("Task Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -501,6 +516,7 @@ var _ = Describe("Task Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.DesireTask(logger, responseRecorder, request)
 		})
 
@@ -528,6 +544,7 @@ var _ = Describe("Task Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -561,6 +578,7 @@ var _ = Describe("Task Handlers", func() {
 
 			JustBeforeEach(func() {
 				request := newTestRequest(requestBody)
+				request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 				ctx = request.Context()
 				handler.StartTask(logger, responseRecorder, request)
 			})
@@ -613,6 +631,7 @@ var _ = Describe("Task Handlers", func() {
 
 				It("logs and writes to the exit channel", func() {
 					Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+					Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 					Eventually(exitCh).Should(Receive())
 				})
 			})
@@ -650,6 +669,7 @@ var _ = Describe("Task Handlers", func() {
 		})
 
 		JustBeforeEach(func() {
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.CancelTask(logger, responseRecorder, request)
 			Expect(responseRecorder.Code).To(Equal(http.StatusOK))
 		})
@@ -696,6 +716,7 @@ var _ = Describe("Task Handlers", func() {
 
 				It("logs and writes to the exit channel", func() {
 					Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+					Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 					Eventually(exitCh).Should(Receive())
 				})
 			})
@@ -736,6 +757,7 @@ var _ = Describe("Task Handlers", func() {
 
 		JustBeforeEach(func() {
 			request = newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.FailTask(logger, responseRecorder, request)
 		})
 
@@ -761,6 +783,7 @@ var _ = Describe("Task Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -795,6 +818,7 @@ var _ = Describe("Task Handlers", func() {
 
 		JustBeforeEach(func() {
 			request = newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.RejectTask(logger, responseRecorder, request)
 		})
 
@@ -819,6 +843,7 @@ var _ = Describe("Task Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -867,6 +892,7 @@ var _ = Describe("Task Handlers", func() {
 
 		JustBeforeEach(func() {
 			request := newTestRequest(requestBody)
+			request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 			handler.CompleteTask(logger, responseRecorder, request)
 		})
 
@@ -896,6 +922,7 @@ var _ = Describe("Task Handlers", func() {
 
 			It("logs and writes to the exit channel", func() {
 				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 				Eventually(exitCh).Should(Receive())
 			})
 		})
@@ -926,6 +953,7 @@ var _ = Describe("Task Handlers", func() {
 
 			JustBeforeEach(func() {
 				request := newTestRequest(requestBody)
+				request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 				handler.ResolvingTask(logger, responseRecorder, request)
 			})
 
@@ -951,6 +979,7 @@ var _ = Describe("Task Handlers", func() {
 
 				It("logs and writes to the exit channel", func() {
 					Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+					Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 					Eventually(exitCh).Should(Receive())
 				})
 			})
@@ -981,6 +1010,7 @@ var _ = Describe("Task Handlers", func() {
 			})
 			JustBeforeEach(func() {
 				request := newTestRequest(requestBody)
+				request.Header.Set(lager.RequestIdHeader, requestIdHeader)
 				handler.DeleteTask(logger, responseRecorder, request)
 			})
 
@@ -1006,6 +1036,7 @@ var _ = Describe("Task Handlers", func() {
 
 				It("logs and writes to the exit channel", func() {
 					Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+					Eventually(logger).Should(gbytes.Say(b3RequestIdHeader))
 					Eventually(exitCh).Should(Receive())
 				})
 			})


### PR DESCRIPTION
Thank you for submitting a pull request to the bbs repository!

We appreciate the contribution. To help us understand the context for your pull request, please fill out this template to the best of your ability.

## Please make sure to complete all of the following steps

1. Check the [Contributing document](https://github.com/cloudfoundry/diego-release/blob/develop/CONTRIBUTING.md) on how to sign the CLA and run tests.
1. Submit your PR to this repo.
1. [**Submit an accompanying PR Review Request**](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=pr-review-request.md&title=%5BBBS+PR+REVIEW%5D%3A) referencing this PR so the Diego Team knows to review your pull request. 
* **Note: this PR will not be reviewed unless you submit the [PR Review Request](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=pr-review-request.md&title=%5BBS+BPR+REVIEW%5D%3A)**.

***************************

## Please provide the following information:

### What is this change about?

Update BBS logging calls to use new `WithTraceInfo()` method, which appends an `trace-id` based on the `VCAP_REQUEST_ID`. This will allow users to trace a request from Gorouter through Diego components. See https://github.com/cloudfoundry/lager/commit/1e35ce1b4e07747ee2f0fa29052ef0f8c56ed3bd

### What problem it is trying to solve?

Allows operators to troubleshoot a workflow through multiple components of CF.


### How should this change be described in diego-release release notes?

Add zipkin trace-id to Diego (using lager `WithTraceInfo()` method).
