### PR TITLE
Add routing info endpoint

### DIFF
--- a/client.go
+++ b/client.go
@@ -168,6 +168,9 @@ type ExternalDesiredLRPClient interface {
 	// Returns all DesiredLRPSchedulingInfos that match the given DesiredLRPFilter
 	DesiredLRPSchedulingInfos(lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRPSchedulingInfo, error)
 
+	// Returns all DesiredLRPRoutingInfos that match the given DesiredLRPFilter
+	DesiredLRPRoutingInfos(lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRP, error)
+
 	// Creates the given DesiredLRP and its corresponding ActualLRPs
 	DesireLRP(lager.Logger, *models.DesiredLRP) error
 
@@ -597,6 +600,20 @@ func (c *client) DesiredLRPSchedulingInfos(logger lager.Logger, filter models.De
 	}
 
 	return response.DesiredLrpSchedulingInfos, response.Error.ToError()
+}
+
+func (c *client) DesiredLRPRoutingInfos(logger lager.Logger, filter models.DesiredLRPFilter) ([]*models.DesiredLRP, error) {
+	request := models.DesiredLRPsRequest{
+		Domain:       filter.Domain,
+		ProcessGuids: filter.ProcessGuids,
+	}
+	response := models.DesiredLRPsResponse{}
+	err := c.doRequest(logger, DesiredLRPRoutingInfosRoute_r0, nil, nil, &request, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.DesiredLrps, response.Error.ToError()
 }
 
 func (c *client) doDesiredLRPLifecycleRequest(logger lager.Logger, route string, request proto.Message) error {

--- a/client.go
+++ b/client.go
@@ -604,7 +604,6 @@ func (c *client) DesiredLRPSchedulingInfos(logger lager.Logger, filter models.De
 
 func (c *client) DesiredLRPRoutingInfos(logger lager.Logger, filter models.DesiredLRPFilter) ([]*models.DesiredLRP, error) {
 	request := models.DesiredLRPsRequest{
-		Domain:       filter.Domain,
 		ProcessGuids: filter.ProcessGuids,
 	}
 	response := models.DesiredLRPsResponse{}

--- a/db/dbfakes/fake_db.go
+++ b/db/dbfakes/fake_db.go
@@ -262,6 +262,21 @@ type FakeDB struct {
 		result1 *models.DesiredLRP
 		result2 error
 	}
+	DesiredLRPRoutingInfosStub        func(context.Context, lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRP, error)
+	desiredLRPRoutingInfosMutex       sync.RWMutex
+	desiredLRPRoutingInfosArgsForCall []struct {
+		arg1 context.Context
+		arg2 lager.Logger
+		arg3 models.DesiredLRPFilter
+	}
+	desiredLRPRoutingInfosReturns struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}
+	desiredLRPRoutingInfosReturnsOnCall map[int]struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}
 	DesiredLRPSchedulingInfosStub        func(context.Context, lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRPSchedulingInfo, error)
 	desiredLRPSchedulingInfosMutex       sync.RWMutex
 	desiredLRPSchedulingInfosArgsForCall []struct {
@@ -1658,6 +1673,72 @@ func (fake *FakeDB) DesiredLRPByProcessGuidReturnsOnCall(i int, result1 *models.
 	}
 	fake.desiredLRPByProcessGuidReturnsOnCall[i] = struct {
 		result1 *models.DesiredLRP
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeDB) DesiredLRPRoutingInfos(arg1 context.Context, arg2 lager.Logger, arg3 models.DesiredLRPFilter) ([]*models.DesiredLRP, error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	ret, specificReturn := fake.desiredLRPRoutingInfosReturnsOnCall[len(fake.desiredLRPRoutingInfosArgsForCall)]
+	fake.desiredLRPRoutingInfosArgsForCall = append(fake.desiredLRPRoutingInfosArgsForCall, struct {
+		arg1 context.Context
+		arg2 lager.Logger
+		arg3 models.DesiredLRPFilter
+	}{arg1, arg2, arg3})
+	stub := fake.DesiredLRPRoutingInfosStub
+	fakeReturns := fake.desiredLRPRoutingInfosReturns
+	fake.recordInvocation("DesiredLRPRoutingInfos", []interface{}{arg1, arg2, arg3})
+	fake.desiredLRPRoutingInfosMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeDB) DesiredLRPRoutingInfosCallCount() int {
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
+	return len(fake.desiredLRPRoutingInfosArgsForCall)
+}
+
+func (fake *FakeDB) DesiredLRPRoutingInfosCalls(stub func(context.Context, lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRP, error)) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = stub
+}
+
+func (fake *FakeDB) DesiredLRPRoutingInfosArgsForCall(i int) (context.Context, lager.Logger, models.DesiredLRPFilter) {
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
+	argsForCall := fake.desiredLRPRoutingInfosArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeDB) DesiredLRPRoutingInfosReturns(result1 []*models.DesiredLRP, result2 error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = nil
+	fake.desiredLRPRoutingInfosReturns = struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeDB) DesiredLRPRoutingInfosReturnsOnCall(i int, result1 []*models.DesiredLRP, result2 error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = nil
+	if fake.desiredLRPRoutingInfosReturnsOnCall == nil {
+		fake.desiredLRPRoutingInfosReturnsOnCall = make(map[int]struct {
+			result1 []*models.DesiredLRP
+			result2 error
+		})
+	}
+	fake.desiredLRPRoutingInfosReturnsOnCall[i] = struct {
+		result1 []*models.DesiredLRP
 		result2 error
 	}{result1, result2}
 }
@@ -3305,6 +3386,8 @@ func (fake *FakeDB) Invocations() map[string][][]interface{} {
 	defer fake.desireTaskMutex.RUnlock()
 	fake.desiredLRPByProcessGuidMutex.RLock()
 	defer fake.desiredLRPByProcessGuidMutex.RUnlock()
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
 	fake.desiredLRPSchedulingInfosMutex.RLock()
 	defer fake.desiredLRPSchedulingInfosMutex.RUnlock()
 	fake.desiredLRPsMutex.RLock()

--- a/db/dbfakes/fake_desired_lrpdb.go
+++ b/db/dbfakes/fake_desired_lrpdb.go
@@ -39,6 +39,21 @@ type FakeDesiredLRPDB struct {
 		result1 *models.DesiredLRP
 		result2 error
 	}
+	DesiredLRPRoutingInfosStub        func(context.Context, lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRP, error)
+	desiredLRPRoutingInfosMutex       sync.RWMutex
+	desiredLRPRoutingInfosArgsForCall []struct {
+		arg1 context.Context
+		arg2 lager.Logger
+		arg3 models.DesiredLRPFilter
+	}
+	desiredLRPRoutingInfosReturns struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}
+	desiredLRPRoutingInfosReturnsOnCall map[int]struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}
 	DesiredLRPSchedulingInfosStub        func(context.Context, lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRPSchedulingInfo, error)
 	desiredLRPSchedulingInfosMutex       sync.RWMutex
 	desiredLRPSchedulingInfosArgsForCall []struct {
@@ -227,6 +242,72 @@ func (fake *FakeDesiredLRPDB) DesiredLRPByProcessGuidReturnsOnCall(i int, result
 	}
 	fake.desiredLRPByProcessGuidReturnsOnCall[i] = struct {
 		result1 *models.DesiredLRP
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeDesiredLRPDB) DesiredLRPRoutingInfos(arg1 context.Context, arg2 lager.Logger, arg3 models.DesiredLRPFilter) ([]*models.DesiredLRP, error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	ret, specificReturn := fake.desiredLRPRoutingInfosReturnsOnCall[len(fake.desiredLRPRoutingInfosArgsForCall)]
+	fake.desiredLRPRoutingInfosArgsForCall = append(fake.desiredLRPRoutingInfosArgsForCall, struct {
+		arg1 context.Context
+		arg2 lager.Logger
+		arg3 models.DesiredLRPFilter
+	}{arg1, arg2, arg3})
+	stub := fake.DesiredLRPRoutingInfosStub
+	fakeReturns := fake.desiredLRPRoutingInfosReturns
+	fake.recordInvocation("DesiredLRPRoutingInfos", []interface{}{arg1, arg2, arg3})
+	fake.desiredLRPRoutingInfosMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeDesiredLRPDB) DesiredLRPRoutingInfosCallCount() int {
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
+	return len(fake.desiredLRPRoutingInfosArgsForCall)
+}
+
+func (fake *FakeDesiredLRPDB) DesiredLRPRoutingInfosCalls(stub func(context.Context, lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRP, error)) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = stub
+}
+
+func (fake *FakeDesiredLRPDB) DesiredLRPRoutingInfosArgsForCall(i int) (context.Context, lager.Logger, models.DesiredLRPFilter) {
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
+	argsForCall := fake.desiredLRPRoutingInfosArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeDesiredLRPDB) DesiredLRPRoutingInfosReturns(result1 []*models.DesiredLRP, result2 error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = nil
+	fake.desiredLRPRoutingInfosReturns = struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeDesiredLRPDB) DesiredLRPRoutingInfosReturnsOnCall(i int, result1 []*models.DesiredLRP, result2 error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = nil
+	if fake.desiredLRPRoutingInfosReturnsOnCall == nil {
+		fake.desiredLRPRoutingInfosReturnsOnCall = make(map[int]struct {
+			result1 []*models.DesiredLRP
+			result2 error
+		})
+	}
+	fake.desiredLRPRoutingInfosReturnsOnCall[i] = struct {
+		result1 []*models.DesiredLRP
 		result2 error
 	}{result1, result2}
 }
@@ -500,6 +581,8 @@ func (fake *FakeDesiredLRPDB) Invocations() map[string][][]interface{} {
 	defer fake.desireLRPMutex.RUnlock()
 	fake.desiredLRPByProcessGuidMutex.RLock()
 	defer fake.desiredLRPByProcessGuidMutex.RUnlock()
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
 	fake.desiredLRPSchedulingInfosMutex.RLock()
 	defer fake.desiredLRPSchedulingInfosMutex.RUnlock()
 	fake.desiredLRPsMutex.RLock()

--- a/db/dbfakes/fake_lrpdb.go
+++ b/db/dbfakes/fake_lrpdb.go
@@ -173,6 +173,21 @@ type FakeLRPDB struct {
 		result1 *models.DesiredLRP
 		result2 error
 	}
+	DesiredLRPRoutingInfosStub        func(context.Context, lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRP, error)
+	desiredLRPRoutingInfosMutex       sync.RWMutex
+	desiredLRPRoutingInfosArgsForCall []struct {
+		arg1 context.Context
+		arg2 lager.Logger
+		arg3 models.DesiredLRPFilter
+	}
+	desiredLRPRoutingInfosReturns struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}
+	desiredLRPRoutingInfosReturnsOnCall map[int]struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}
 	DesiredLRPSchedulingInfosStub        func(context.Context, lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRPSchedulingInfo, error)
 	desiredLRPSchedulingInfosMutex       sync.RWMutex
 	desiredLRPSchedulingInfosArgsForCall []struct {
@@ -983,6 +998,72 @@ func (fake *FakeLRPDB) DesiredLRPByProcessGuidReturnsOnCall(i int, result1 *mode
 	}{result1, result2}
 }
 
+func (fake *FakeLRPDB) DesiredLRPRoutingInfos(arg1 context.Context, arg2 lager.Logger, arg3 models.DesiredLRPFilter) ([]*models.DesiredLRP, error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	ret, specificReturn := fake.desiredLRPRoutingInfosReturnsOnCall[len(fake.desiredLRPRoutingInfosArgsForCall)]
+	fake.desiredLRPRoutingInfosArgsForCall = append(fake.desiredLRPRoutingInfosArgsForCall, struct {
+		arg1 context.Context
+		arg2 lager.Logger
+		arg3 models.DesiredLRPFilter
+	}{arg1, arg2, arg3})
+	stub := fake.DesiredLRPRoutingInfosStub
+	fakeReturns := fake.desiredLRPRoutingInfosReturns
+	fake.recordInvocation("DesiredLRPRoutingInfos", []interface{}{arg1, arg2, arg3})
+	fake.desiredLRPRoutingInfosMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeLRPDB) DesiredLRPRoutingInfosCallCount() int {
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
+	return len(fake.desiredLRPRoutingInfosArgsForCall)
+}
+
+func (fake *FakeLRPDB) DesiredLRPRoutingInfosCalls(stub func(context.Context, lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRP, error)) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = stub
+}
+
+func (fake *FakeLRPDB) DesiredLRPRoutingInfosArgsForCall(i int) (context.Context, lager.Logger, models.DesiredLRPFilter) {
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
+	argsForCall := fake.desiredLRPRoutingInfosArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeLRPDB) DesiredLRPRoutingInfosReturns(result1 []*models.DesiredLRP, result2 error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = nil
+	fake.desiredLRPRoutingInfosReturns = struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeLRPDB) DesiredLRPRoutingInfosReturnsOnCall(i int, result1 []*models.DesiredLRP, result2 error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = nil
+	if fake.desiredLRPRoutingInfosReturnsOnCall == nil {
+		fake.desiredLRPRoutingInfosReturnsOnCall = make(map[int]struct {
+			result1 []*models.DesiredLRP
+			result2 error
+		})
+	}
+	fake.desiredLRPRoutingInfosReturnsOnCall[i] = struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeLRPDB) DesiredLRPSchedulingInfos(arg1 context.Context, arg2 lager.Logger, arg3 models.DesiredLRPFilter) ([]*models.DesiredLRPSchedulingInfo, error) {
 	fake.desiredLRPSchedulingInfosMutex.Lock()
 	ret, specificReturn := fake.desiredLRPSchedulingInfosReturnsOnCall[len(fake.desiredLRPSchedulingInfosArgsForCall)]
@@ -1550,6 +1631,8 @@ func (fake *FakeLRPDB) Invocations() map[string][][]interface{} {
 	defer fake.desireLRPMutex.RUnlock()
 	fake.desiredLRPByProcessGuidMutex.RLock()
 	defer fake.desiredLRPByProcessGuidMutex.RUnlock()
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
 	fake.desiredLRPSchedulingInfosMutex.RLock()
 	defer fake.desiredLRPSchedulingInfosMutex.RUnlock()
 	fake.desiredLRPsMutex.RLock()

--- a/db/desired_lrp_db.go
+++ b/db/desired_lrp_db.go
@@ -14,6 +14,7 @@ type DesiredLRPDB interface {
 	DesiredLRPByProcessGuid(ctx context.Context, logger lager.Logger, processGuid string) (*models.DesiredLRP, error)
 
 	DesiredLRPSchedulingInfos(ctx context.Context, logger lager.Logger, filter models.DesiredLRPFilter) ([]*models.DesiredLRPSchedulingInfo, error)
+	DesiredLRPRoutingInfos(ctx context.Context, logger lager.Logger, filter models.DesiredLRPFilter) ([]*models.DesiredLRP, error)
 
 	DesireLRP(ctx context.Context, logger lager.Logger, desiredLRP *models.DesiredLRP) error
 	UpdateDesiredLRP(ctx context.Context, logger lager.Logger, processGuid string, update *models.DesiredLRPUpdate) (beforeDesiredLRP *models.DesiredLRP, err error)

--- a/db/sqldb/desired_lrp_db.go
+++ b/db/sqldb/desired_lrp_db.go
@@ -205,6 +205,60 @@ func (db *SQLDB) DesiredLRPSchedulingInfos(ctx context.Context, logger lager.Log
 	return results, err
 }
 
+func (db *SQLDB) DesiredLRPRoutingInfos(ctx context.Context, logger lager.Logger, filter models.DesiredLRPFilter) ([]*models.DesiredLRP, error) {
+	logger = logger.Session("db-desired-lrps-routing-infos", lager.Data{"filter": filter})
+	logger.Debug("starting")
+	defer logger.Debug("complete")
+
+	var wheres []string
+	var values []interface{}
+
+	if filter.Domain != "" {
+		wheres = append(wheres, "domain = ?")
+		values = append(values, filter.Domain)
+	}
+
+	if len(filter.ProcessGuids) > 0 {
+		wheres = append(wheres, whereClauseForProcessGuids(filter.ProcessGuids))
+
+		for _, guid := range filter.ProcessGuids {
+			values = append(values, guid)
+		}
+	}
+
+	results := []*models.DesiredLRP{}
+
+	err := db.transact(ctx, logger, func(logger lager.Logger, tx helpers.Tx) error {
+		rows, err := db.all(ctx, logger, tx, desiredLRPsTable,
+			routingInfoColumns, helpers.NoLockRow,
+			strings.Join(wheres, " AND "), values...,
+		)
+		if err != nil {
+			logger.Error("failed-query", err)
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			desiredLRPRoutingInfo, err := db.fetchDesiredLRPRoutingInfo(logger, rows)
+			if err != nil {
+				logger.Error("failed-reading-row", err)
+				continue
+			}
+			results = append(results, desiredLRPRoutingInfo)
+		}
+
+		if rows.Err() != nil {
+			logger.Error("failed-fetching-row", rows.Err())
+			return db.convertSQLError(rows.Err())
+		}
+
+		return nil
+	})
+
+	return results, err
+}
+
 func (db *SQLDB) UpdateDesiredLRP(ctx context.Context, logger lager.Logger, processGuid string, update *models.DesiredLRPUpdate) (*models.DesiredLRP, error) {
 	logger = logger.Session("db-update-desired-lrp", lager.Data{"process_guid": processGuid})
 	logger.Info("starting")
@@ -362,6 +416,56 @@ func (db *SQLDB) fetchDesiredLRPSchedulingInfoAndMore(logger lager.Logger, scann
 	}
 
 	return schedulingInfo, nil
+}
+
+func (db *SQLDB) fetchDesiredLRPRoutingInfo(logger lager.Logger, scanner helpers.RowScanner, dest ...interface{}) (*models.DesiredLRP, error) {
+	routingInfo := &models.DesiredLRP{}
+	var modificationTagEpoch string
+	var modificationTagIndex uint32
+	var routeData, runInfoData []byte
+	values := []interface{}{
+		&routingInfo.ProcessGuid,
+		&routingInfo.Domain,
+		&routingInfo.LogGuid,
+		&routingInfo.Instances,
+		&routeData,
+		&modificationTagEpoch,
+		&modificationTagIndex,
+		&runInfoData,
+	}
+
+	err := scanner.Scan(values...)
+	if err == sql.ErrNoRows {
+		return nil, err
+	}
+
+	if err != nil {
+		logger.Error("failed-scanning", err)
+		return nil, err
+	}
+	var routes models.Routes
+	encodedData, err := db.encoder.Decode(routeData)
+	if err != nil {
+		logger.Error("failed-decrypting-routes", err)
+		return nil, err
+	}
+	err = json.Unmarshal(encodedData, &routes)
+	if err != nil {
+		logger.Error("failed-parsing-routes", err)
+		return nil, err
+	}
+	routingInfo.Routes = &routes
+
+	var runInfo models.DesiredLRPRunInfo
+	err = db.deserializeModel(logger, runInfoData, &runInfo)
+	if err != nil {
+		logger.Error("failed-decrypting-run-info", err)
+		return nil, err
+	}
+	routingInfo.MetricTags = runInfo.MetricTags
+	routingInfo.ModificationTag = &models.ModificationTag{Epoch: modificationTagEpoch, Index: modificationTagIndex}
+
+	return routingInfo, nil
 }
 
 func (db *SQLDB) lockDesiredLRPByGuidForUpdate(ctx context.Context, logger lager.Logger, processGuid string, tx helpers.Tx) error {

--- a/db/sqldb/desired_lrp_db.go
+++ b/db/sqldb/desired_lrp_db.go
@@ -213,11 +213,6 @@ func (db *SQLDB) DesiredLRPRoutingInfos(ctx context.Context, logger lager.Logger
 	var wheres []string
 	var values []interface{}
 
-	if filter.Domain != "" {
-		wheres = append(wheres, "domain = ?")
-		values = append(values, filter.Domain)
-	}
-
 	if len(filter.ProcessGuids) > 0 {
 		wheres = append(wheres, whereClauseForProcessGuids(filter.ProcessGuids))
 

--- a/db/sqldb/desired_lrp_db_test.go
+++ b/db/sqldb/desired_lrp_db_test.go
@@ -329,7 +329,7 @@ var _ = Describe("DesiredLRPDB", func() {
 		})
 	})
 
-	FDescribe("DesiredLRPRoutingInfos", func() {
+	Describe("DesiredLRPRoutingInfos", func() {
 		var expectedDesiredLRPRoutingInfos []*models.DesiredLRP
 		var expectedDesiredLRPs []*models.DesiredLRP
 
@@ -357,15 +357,6 @@ var _ = Describe("DesiredLRPDB", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(desiredLRPRoutingInfos).To(HaveLen(3))
 			Expect(desiredLRPRoutingInfos).To(ConsistOf(expectedDesiredLRPRoutingInfos))
-		})
-
-		Context("when filtering by domain", func() {
-			It("returns the filtered routing infos", func() {
-				desiredLRPRoutingInfos, err := sqlDB.DesiredLRPRoutingInfos(ctx, logger, models.DesiredLRPFilter{Domain: "domain-1"})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(desiredLRPRoutingInfos).To(HaveLen(1))
-				Expect(desiredLRPRoutingInfos[0]).To(BeEquivalentTo(expectedDesiredLRPRoutingInfos[0]))
-			})
 		})
 
 		Context("when filtering by process guids", func() {

--- a/db/sqldb/queries.go
+++ b/db/sqldb/queries.go
@@ -20,6 +20,17 @@ const (
 )
 
 var (
+	routingInfoColumns = helpers.ColumnList{
+		desiredLRPsTable + ".process_guid",
+		desiredLRPsTable + ".domain",
+		desiredLRPsTable + ".log_guid",
+		desiredLRPsTable + ".instances",
+		desiredLRPsTable + ".routes",
+		desiredLRPsTable + ".modification_tag_epoch",
+		desiredLRPsTable + ".modification_tag_index",
+		desiredLRPsTable + ".run_info",
+	}
+
 	schedulingInfoColumns = helpers.ColumnList{
 		desiredLRPsTable + ".process_guid",
 		desiredLRPsTable + ".domain",

--- a/fake_bbs/fake_client.go
+++ b/fake_bbs/fake_client.go
@@ -146,6 +146,20 @@ type FakeClient struct {
 		result1 *models.DesiredLRP
 		result2 error
 	}
+	DesiredLRPRoutingInfosStub        func(lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRP, error)
+	desiredLRPRoutingInfosMutex       sync.RWMutex
+	desiredLRPRoutingInfosArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 models.DesiredLRPFilter
+	}
+	desiredLRPRoutingInfosReturns struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}
+	desiredLRPRoutingInfosReturnsOnCall map[int]struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}
 	DesiredLRPSchedulingInfosStub        func(lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRPSchedulingInfo, error)
 	desiredLRPSchedulingInfosMutex       sync.RWMutex
 	desiredLRPSchedulingInfosArgsForCall []struct {
@@ -1036,6 +1050,71 @@ func (fake *FakeClient) DesiredLRPByProcessGuidReturnsOnCall(i int, result1 *mod
 	}
 	fake.desiredLRPByProcessGuidReturnsOnCall[i] = struct {
 		result1 *models.DesiredLRP
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) DesiredLRPRoutingInfos(arg1 lager.Logger, arg2 models.DesiredLRPFilter) ([]*models.DesiredLRP, error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	ret, specificReturn := fake.desiredLRPRoutingInfosReturnsOnCall[len(fake.desiredLRPRoutingInfosArgsForCall)]
+	fake.desiredLRPRoutingInfosArgsForCall = append(fake.desiredLRPRoutingInfosArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 models.DesiredLRPFilter
+	}{arg1, arg2})
+	stub := fake.DesiredLRPRoutingInfosStub
+	fakeReturns := fake.desiredLRPRoutingInfosReturns
+	fake.recordInvocation("DesiredLRPRoutingInfos", []interface{}{arg1, arg2})
+	fake.desiredLRPRoutingInfosMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) DesiredLRPRoutingInfosCallCount() int {
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
+	return len(fake.desiredLRPRoutingInfosArgsForCall)
+}
+
+func (fake *FakeClient) DesiredLRPRoutingInfosCalls(stub func(lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRP, error)) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = stub
+}
+
+func (fake *FakeClient) DesiredLRPRoutingInfosArgsForCall(i int) (lager.Logger, models.DesiredLRPFilter) {
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
+	argsForCall := fake.desiredLRPRoutingInfosArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeClient) DesiredLRPRoutingInfosReturns(result1 []*models.DesiredLRP, result2 error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = nil
+	fake.desiredLRPRoutingInfosReturns = struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) DesiredLRPRoutingInfosReturnsOnCall(i int, result1 []*models.DesiredLRP, result2 error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = nil
+	if fake.desiredLRPRoutingInfosReturnsOnCall == nil {
+		fake.desiredLRPRoutingInfosReturnsOnCall = make(map[int]struct {
+			result1 []*models.DesiredLRP
+			result2 error
+		})
+	}
+	fake.desiredLRPRoutingInfosReturnsOnCall[i] = struct {
+		result1 []*models.DesiredLRP
 		result2 error
 	}{result1, result2}
 }
@@ -2276,6 +2355,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.desireTaskMutex.RUnlock()
 	fake.desiredLRPByProcessGuidMutex.RLock()
 	defer fake.desiredLRPByProcessGuidMutex.RUnlock()
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
 	fake.desiredLRPSchedulingInfosMutex.RLock()
 	defer fake.desiredLRPSchedulingInfosMutex.RUnlock()
 	fake.desiredLRPsMutex.RLock()

--- a/fake_bbs/fake_internal_client.go
+++ b/fake_bbs/fake_internal_client.go
@@ -189,6 +189,20 @@ type FakeInternalClient struct {
 		result1 *models.DesiredLRP
 		result2 error
 	}
+	DesiredLRPRoutingInfosStub        func(lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRP, error)
+	desiredLRPRoutingInfosMutex       sync.RWMutex
+	desiredLRPRoutingInfosArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 models.DesiredLRPFilter
+	}
+	desiredLRPRoutingInfosReturns struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}
+	desiredLRPRoutingInfosReturnsOnCall map[int]struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}
 	DesiredLRPSchedulingInfosStub        func(lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRPSchedulingInfo, error)
 	desiredLRPSchedulingInfosMutex       sync.RWMutex
 	desiredLRPSchedulingInfosArgsForCall []struct {
@@ -1432,6 +1446,71 @@ func (fake *FakeInternalClient) DesiredLRPByProcessGuidReturnsOnCall(i int, resu
 	}
 	fake.desiredLRPByProcessGuidReturnsOnCall[i] = struct {
 		result1 *models.DesiredLRP
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeInternalClient) DesiredLRPRoutingInfos(arg1 lager.Logger, arg2 models.DesiredLRPFilter) ([]*models.DesiredLRP, error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	ret, specificReturn := fake.desiredLRPRoutingInfosReturnsOnCall[len(fake.desiredLRPRoutingInfosArgsForCall)]
+	fake.desiredLRPRoutingInfosArgsForCall = append(fake.desiredLRPRoutingInfosArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 models.DesiredLRPFilter
+	}{arg1, arg2})
+	stub := fake.DesiredLRPRoutingInfosStub
+	fakeReturns := fake.desiredLRPRoutingInfosReturns
+	fake.recordInvocation("DesiredLRPRoutingInfos", []interface{}{arg1, arg2})
+	fake.desiredLRPRoutingInfosMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeInternalClient) DesiredLRPRoutingInfosCallCount() int {
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
+	return len(fake.desiredLRPRoutingInfosArgsForCall)
+}
+
+func (fake *FakeInternalClient) DesiredLRPRoutingInfosCalls(stub func(lager.Logger, models.DesiredLRPFilter) ([]*models.DesiredLRP, error)) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = stub
+}
+
+func (fake *FakeInternalClient) DesiredLRPRoutingInfosArgsForCall(i int) (lager.Logger, models.DesiredLRPFilter) {
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
+	argsForCall := fake.desiredLRPRoutingInfosArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeInternalClient) DesiredLRPRoutingInfosReturns(result1 []*models.DesiredLRP, result2 error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = nil
+	fake.desiredLRPRoutingInfosReturns = struct {
+		result1 []*models.DesiredLRP
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeInternalClient) DesiredLRPRoutingInfosReturnsOnCall(i int, result1 []*models.DesiredLRP, result2 error) {
+	fake.desiredLRPRoutingInfosMutex.Lock()
+	defer fake.desiredLRPRoutingInfosMutex.Unlock()
+	fake.DesiredLRPRoutingInfosStub = nil
+	if fake.desiredLRPRoutingInfosReturnsOnCall == nil {
+		fake.desiredLRPRoutingInfosReturnsOnCall = make(map[int]struct {
+			result1 []*models.DesiredLRP
+			result2 error
+		})
+	}
+	fake.desiredLRPRoutingInfosReturnsOnCall[i] = struct {
+		result1 []*models.DesiredLRP
 		result2 error
 	}{result1, result2}
 }
@@ -3403,6 +3482,8 @@ func (fake *FakeInternalClient) Invocations() map[string][][]interface{} {
 	defer fake.desireTaskMutex.RUnlock()
 	fake.desiredLRPByProcessGuidMutex.RLock()
 	defer fake.desiredLRPByProcessGuidMutex.RUnlock()
+	fake.desiredLRPRoutingInfosMutex.RLock()
+	defer fake.desiredLRPRoutingInfosMutex.RUnlock()
 	fake.desiredLRPSchedulingInfosMutex.RLock()
 	defer fake.desiredLRPSchedulingInfosMutex.RUnlock()
 	fake.desiredLRPsMutex.RLock()

--- a/handlers/desired_lrp_handlers.go
+++ b/handlers/desired_lrp_handlers.go
@@ -147,6 +147,29 @@ func (h *DesiredLRPHandler) DesiredLRPSchedulingInfos(logger lager.Logger, w htt
 	exitIfUnrecoverable(logger, h.exitChan, response.Error)
 }
 
+func (h *DesiredLRPHandler) DesiredLRPRoutingInfos(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
+	var err error
+	logger = logger.Session("desired-lrp-routing-infos")
+	logger.Debug("starting")
+	defer logger.Debug("complete")
+
+	request := &models.DesiredLRPsRequest{}
+	response := &models.DesiredLRPsResponse{}
+
+	err = parseRequest(logger, req, request)
+	if err == nil {
+		filter := models.DesiredLRPFilter{
+			Domain:       request.Domain,
+			ProcessGuids: request.ProcessGuids,
+		}
+		response.DesiredLrps, err = h.desiredLRPDB.DesiredLRPRoutingInfos(req.Context(), logger, filter)
+	}
+
+	response.Error = models.ConvertError(err)
+	writeResponse(w, response)
+	exitIfUnrecoverable(logger, h.exitChan, response.Error)
+}
+
 func (h *DesiredLRPHandler) DesireDesiredLRP(logger lager.Logger, w http.ResponseWriter, req *http.Request) {
 	logger = logger.Session("desire-lrp")
 

--- a/handlers/desired_lrp_handlers_test.go
+++ b/handlers/desired_lrp_handlers_test.go
@@ -723,6 +723,118 @@ var _ = Describe("DesiredLRP Handlers", func() {
 		})
 	})
 
+	Describe("DesiredLRPRoutingInfos", func() {
+		var (
+			requestBody  interface{}
+			routingInfo1 models.DesiredLRP
+			routingInfo2 models.DesiredLRP
+		)
+
+		BeforeEach(func() {
+			requestBody = &models.DesiredLRPsRequest{}
+			routingInfo1 = models.DesiredLRP{}
+			routingInfo2 = models.DesiredLRP{}
+		})
+
+		JustBeforeEach(func() {
+			request := newTestRequest(requestBody)
+			handler.DesiredLRPRoutingInfos(logger, responseRecorder, request)
+		})
+
+		Context("when reading routing infos from DB succeeds", func() {
+			var routingInfos []*models.DesiredLRP
+
+			BeforeEach(func() {
+				routingInfos = []*models.DesiredLRP{&routingInfo1, &routingInfo2}
+				fakeDesiredLRPDB.DesiredLRPRoutingInfosReturns(routingInfos, nil)
+			})
+
+			It("returns a list of desired lrps", func() {
+				Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+				response := models.DesiredLRPsResponse{}
+				err := response.Unmarshal(responseRecorder.Body.Bytes())
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(response.Error).To(BeNil())
+				Expect(response.DesiredLrps).To(Equal(routingInfos))
+			})
+
+			Context("and no filter is provided", func() {
+				It("call the DB with no filters to retrieve the desired lrps", func() {
+					Expect(fakeDesiredLRPDB.DesiredLRPRoutingInfosCallCount()).To(Equal(1))
+					_, _, filter := fakeDesiredLRPDB.DesiredLRPRoutingInfosArgsForCall(0)
+					Expect(filter).To(Equal(models.DesiredLRPFilter{}))
+				})
+			})
+
+			Context("and filtering by domain", func() {
+				BeforeEach(func() {
+					requestBody = &models.DesiredLRPsRequest{Domain: "domain-1"}
+				})
+
+				It("call the DB with the domain filter to retrieve the desired lrps", func() {
+					Expect(fakeDesiredLRPDB.DesiredLRPRoutingInfosCallCount()).To(Equal(1))
+					_, _, filter := fakeDesiredLRPDB.DesiredLRPRoutingInfosArgsForCall(0)
+					Expect(filter.Domain).To(Equal("domain-1"))
+				})
+			})
+
+			Context("and filtering by process guids", func() {
+				BeforeEach(func() {
+					requestBody = &models.DesiredLRPsRequest{ProcessGuids: []string{"guid-1", "guid-2"}}
+				})
+
+				It("call the DB with the process guids filter to retrieve the desired lrps", func() {
+					Expect(fakeDesiredLRPDB.DesiredLRPRoutingInfosCallCount()).To(Equal(1))
+					_, _, filter := fakeDesiredLRPDB.DesiredLRPRoutingInfosArgsForCall(0)
+					Expect(filter.ProcessGuids).To(Equal([]string{"guid-1", "guid-2"}))
+				})
+			})
+		})
+
+		Context("when the DB returns no desired lrps", func() {
+			BeforeEach(func() {
+				fakeDesiredLRPDB.DesiredLRPRoutingInfosReturns([]*models.DesiredLRP{}, nil)
+			})
+
+			It("returns an empty list", func() {
+				Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+				response := models.DesiredLRPsResponse{}
+				err := response.Unmarshal(responseRecorder.Body.Bytes())
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(response.Error).To(BeNil())
+				Expect(response.DesiredLrps).To(BeEmpty())
+			})
+		})
+
+		Context("when the DB returns an unrecoverable error", func() {
+			BeforeEach(func() {
+				fakeDesiredLRPDB.DesiredLRPRoutingInfosReturns([]*models.DesiredLRP{}, models.NewUnrecoverableError(nil))
+			})
+
+			It("logs and writes to the exit channel", func() {
+				Eventually(logger).Should(gbytes.Say("unrecoverable-error"))
+				Eventually(exitCh).Should(Receive())
+			})
+		})
+
+		Context("when the DB errors out", func() {
+			BeforeEach(func() {
+				fakeDesiredLRPDB.DesiredLRPRoutingInfosReturns([]*models.DesiredLRP{}, models.ErrUnknownError)
+			})
+
+			It("provides relevant error information", func() {
+				Expect(responseRecorder.Code).To(Equal(http.StatusOK))
+				response := models.DesiredLRPsResponse{}
+				err := response.Unmarshal(responseRecorder.Body.Bytes())
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(response.Error).To(Equal(models.ErrUnknownError))
+			})
+		})
+	})
+
 	Describe("DesireDesiredLRP", func() {
 		var (
 			desiredLRP *models.DesiredLRP

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -102,6 +102,7 @@ func New(
 		bbs.DesiredLRPsRoute_r2:               route(middleware.RecordLatency(middleware.LogWrap(logger, accessLogger, desiredLRPHandler.DesiredLRPs_r2), emitter)),             // DEPRECATED
 		bbs.DesiredLRPByProcessGuidRoute_r2:   route(middleware.RecordLatency(middleware.LogWrap(logger, accessLogger, desiredLRPHandler.DesiredLRPByProcessGuid_r2), emitter)), // DEPRECATED
 		bbs.DesiredLRPSchedulingInfosRoute_r0: route(middleware.RecordLatency(middleware.LogWrap(logger, accessLogger, desiredLRPHandler.DesiredLRPSchedulingInfos), emitter)),
+		bbs.DesiredLRPRoutingInfosRoute_r0:    route(middleware.RecordLatency(middleware.LogWrap(logger, accessLogger, desiredLRPHandler.DesiredLRPRoutingInfos), emitter)),
 		bbs.DesireDesiredLRPRoute_r2:          route(middleware.RecordLatency(middleware.LogWrap(logger, accessLogger, desiredLRPHandler.DesireDesiredLRP), emitter)),
 		bbs.UpdateDesiredLRPRoute_r0:          route(middleware.RecordLatency(middleware.LogWrap(logger, accessLogger, desiredLRPHandler.UpdateDesiredLRP), emitter)),
 		bbs.RemoveDesiredLRPRoute_r0:          route(middleware.RecordLatency(middleware.LogWrap(logger, accessLogger, desiredLRPHandler.RemoveDesiredLRP), emitter)),

--- a/models/desired_lrp.go
+++ b/models/desired_lrp.go
@@ -240,6 +240,26 @@ func (d *DesiredLRP) DesiredLRPSchedulingInfo() DesiredLRPSchedulingInfo {
 	)
 }
 
+func (d *DesiredLRP) DesiredLRPRoutingInfo() DesiredLRP {
+	var routes Routes
+	if d.Routes != nil {
+		routes = *d.Routes
+	}
+
+	var modificationTag ModificationTag
+	if d.ModificationTag != nil {
+		modificationTag = *d.ModificationTag
+	}
+
+	return NewDesiredLRPRoutingInfo(
+		d.DesiredLRPKey(),
+		d.Instances,
+		&routes,
+		&modificationTag,
+		d.MetricTags,
+	)
+}
+
 func (d *DesiredLRP) DesiredLRPRunInfo(createdAt time.Time) DesiredLRPRunInfo {
 	environmentVariables := make([]EnvironmentVariable, len(d.EnvironmentVariables))
 	for i := range d.EnvironmentVariables {
@@ -521,6 +541,24 @@ func NewDesiredLRPSchedulingInfo(
 		ModificationTag:    modTag,
 		VolumePlacement:    volumePlacement,
 		PlacementTags:      placementTags,
+	}
+}
+
+func NewDesiredLRPRoutingInfo(
+	key DesiredLRPKey,
+	instances int32,
+	routes *Routes,
+	modTag *ModificationTag,
+	metrTags map[string]*MetricTagValue,
+) DesiredLRP {
+	return DesiredLRP{
+		ProcessGuid:     key.ProcessGuid,
+		Domain:          key.Domain,
+		LogGuid:         key.LogGuid,
+		Instances:       instances,
+		Routes:          routes,
+		ModificationTag: modTag,
+		MetricTags:      metrTags,
 	}
 }
 

--- a/routes.go
+++ b/routes.go
@@ -36,6 +36,7 @@ const (
 	// Desired LRPs
 	DesiredLRPsRoute_r3               = "DesiredLRPs"
 	DesiredLRPSchedulingInfosRoute_r0 = "DesiredLRPSchedulingInfos"
+	DesiredLRPRoutingInfosRoute_r0    = "DesiredLRPRoutingInfos"
 	DesiredLRPByProcessGuidRoute_r3   = "DesiredLRPByProcessGuid"
 	DesiredLRPsRoute_r2               = "DesiredLRPs_r2"             // DEPRECATED
 	DesiredLRPByProcessGuidRoute_r2   = "DesiredLRPByProcessGuid_r2" // DEPRECATED
@@ -104,6 +105,7 @@ var Routes = rata.Routes{
 
 	// Desired LRPs
 	{Path: "/v1/desired_lrp_scheduling_infos/list", Method: "POST", Name: DesiredLRPSchedulingInfosRoute_r0},
+	{Path: "/v1/desired_lrp_routing_infos/list", Method: "POST", Name: DesiredLRPRoutingInfosRoute_r0},
 
 	{Path: "/v1/desired_lrps/list.r3", Method: "POST", Name: DesiredLRPsRoute_r3},
 	{Path: "/v1/desired_lrps/get_by_process_guid.r3", Method: "POST", Name: DesiredLRPByProcessGuidRoute_r3},


### PR DESCRIPTION
This PR is related to this issue: https://github.com/cloudfoundry/diego-release/issues/678. As discussed, here we introduce a new endpoint in the bbs - routing_info - which the route emitter can use when syncing to retrieve a desiredLRP that includes only the information the route emitter needs. 

In cases where there are a huge amount of security groups in a single space and multiple apps deployed in that space we notice that the network traffic consistently increases as more apps are added to a space. After investigation we found that it was due to the large amount of security groups being sent to the route emitters. 

With this approach, we see a great drop in network load when we do have such large spaces and a lot of security groups. We do not introduce a new structure of the desiredLRP as agreed previously, but just return a desiredLRP with only these fields set:

- process_guid
- domain
- log_guid
- instances
- routes
- modification_tag_epoch
- modification_tag_index
- metric_tags 

The run_info is still retrieved and decrypted since we need the metric_tags that are in it, but only the tags are returned. 

One thing to mention is that this route will be used by the route emitter only when we sync - every 60s, which still brings great improvements, but in all other cases, we still receive the desiredLRP trough the event emitted by BBS. 


