### PR TITLE
Avoid race condition when replacement for suspect LRP has started

### DIFF
--- a/db/dbfakes/fake_db.go
+++ b/db/dbfakes/fake_db.go
@@ -402,6 +402,26 @@ type FakeDB struct {
 	performEncryptionReturnsOnCall map[int]struct {
 		result1 error
 	}
+	PromoteSuspectActualLRPStub        func(context.Context, lager.Logger, string, int32) (*models.ActualLRP, *models.ActualLRP, *models.ActualLRP, error)
+	promoteSuspectActualLRPMutex       sync.RWMutex
+	promoteSuspectActualLRPArgsForCall []struct {
+		arg1 context.Context
+		arg2 lager.Logger
+		arg3 string
+		arg4 int32
+	}
+	promoteSuspectActualLRPReturns struct {
+		result1 *models.ActualLRP
+		result2 *models.ActualLRP
+		result3 *models.ActualLRP
+		result4 error
+	}
+	promoteSuspectActualLRPReturnsOnCall map[int]struct {
+		result1 *models.ActualLRP
+		result2 *models.ActualLRP
+		result3 *models.ActualLRP
+		result4 error
+	}
 	RejectTaskStub        func(context.Context, lager.Logger, string, string) (*models.Task, *models.Task, error)
 	rejectTaskMutex       sync.RWMutex
 	rejectTaskArgsForCall []struct {
@@ -2282,6 +2302,79 @@ func (fake *FakeDB) PerformEncryptionReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeDB) PromoteSuspectActualLRP(arg1 context.Context, arg2 lager.Logger, arg3 string, arg4 int32) (*models.ActualLRP, *models.ActualLRP, *models.ActualLRP, error) {
+	fake.promoteSuspectActualLRPMutex.Lock()
+	ret, specificReturn := fake.promoteSuspectActualLRPReturnsOnCall[len(fake.promoteSuspectActualLRPArgsForCall)]
+	fake.promoteSuspectActualLRPArgsForCall = append(fake.promoteSuspectActualLRPArgsForCall, struct {
+		arg1 context.Context
+		arg2 lager.Logger
+		arg3 string
+		arg4 int32
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.PromoteSuspectActualLRPStub
+	fakeReturns := fake.promoteSuspectActualLRPReturns
+	fake.recordInvocation("PromoteSuspectActualLRP", []interface{}{arg1, arg2, arg3, arg4})
+	fake.promoteSuspectActualLRPMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3, ret.result4
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
+}
+
+func (fake *FakeDB) PromoteSuspectActualLRPCallCount() int {
+	fake.promoteSuspectActualLRPMutex.RLock()
+	defer fake.promoteSuspectActualLRPMutex.RUnlock()
+	return len(fake.promoteSuspectActualLRPArgsForCall)
+}
+
+func (fake *FakeDB) PromoteSuspectActualLRPCalls(stub func(context.Context, lager.Logger, string, int32) (*models.ActualLRP, *models.ActualLRP, *models.ActualLRP, error)) {
+	fake.promoteSuspectActualLRPMutex.Lock()
+	defer fake.promoteSuspectActualLRPMutex.Unlock()
+	fake.PromoteSuspectActualLRPStub = stub
+}
+
+func (fake *FakeDB) PromoteSuspectActualLRPArgsForCall(i int) (context.Context, lager.Logger, string, int32) {
+	fake.promoteSuspectActualLRPMutex.RLock()
+	defer fake.promoteSuspectActualLRPMutex.RUnlock()
+	argsForCall := fake.promoteSuspectActualLRPArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeDB) PromoteSuspectActualLRPReturns(result1 *models.ActualLRP, result2 *models.ActualLRP, result3 *models.ActualLRP, result4 error) {
+	fake.promoteSuspectActualLRPMutex.Lock()
+	defer fake.promoteSuspectActualLRPMutex.Unlock()
+	fake.PromoteSuspectActualLRPStub = nil
+	fake.promoteSuspectActualLRPReturns = struct {
+		result1 *models.ActualLRP
+		result2 *models.ActualLRP
+		result3 *models.ActualLRP
+		result4 error
+	}{result1, result2, result3, result4}
+}
+
+func (fake *FakeDB) PromoteSuspectActualLRPReturnsOnCall(i int, result1 *models.ActualLRP, result2 *models.ActualLRP, result3 *models.ActualLRP, result4 error) {
+	fake.promoteSuspectActualLRPMutex.Lock()
+	defer fake.promoteSuspectActualLRPMutex.Unlock()
+	fake.PromoteSuspectActualLRPStub = nil
+	if fake.promoteSuspectActualLRPReturnsOnCall == nil {
+		fake.promoteSuspectActualLRPReturnsOnCall = make(map[int]struct {
+			result1 *models.ActualLRP
+			result2 *models.ActualLRP
+			result3 *models.ActualLRP
+			result4 error
+		})
+	}
+	fake.promoteSuspectActualLRPReturnsOnCall[i] = struct {
+		result1 *models.ActualLRP
+		result2 *models.ActualLRP
+		result3 *models.ActualLRP
+		result4 error
+	}{result1, result2, result3, result4}
+}
+
 func (fake *FakeDB) RejectTask(arg1 context.Context, arg2 lager.Logger, arg3 string, arg4 string) (*models.Task, *models.Task, error) {
 	fake.rejectTaskMutex.Lock()
 	ret, specificReturn := fake.rejectTaskReturnsOnCall[len(fake.rejectTaskArgsForCall)]
@@ -3404,6 +3497,8 @@ func (fake *FakeDB) Invocations() map[string][][]interface{} {
 	defer fake.freshDomainsMutex.RUnlock()
 	fake.performEncryptionMutex.RLock()
 	defer fake.performEncryptionMutex.RUnlock()
+	fake.promoteSuspectActualLRPMutex.RLock()
+	defer fake.promoteSuspectActualLRPMutex.RUnlock()
 	fake.rejectTaskMutex.RLock()
 	defer fake.rejectTaskMutex.RUnlock()
 	fake.removeActualLRPMutex.RLock()

--- a/db/dbfakes/fake_suspect_db.go
+++ b/db/dbfakes/fake_suspect_db.go
@@ -11,6 +11,26 @@ import (
 )
 
 type FakeSuspectDB struct {
+	PromoteSuspectActualLRPStub        func(context.Context, lager.Logger, string, int32) (*models.ActualLRP, *models.ActualLRP, *models.ActualLRP, error)
+	promoteSuspectActualLRPMutex       sync.RWMutex
+	promoteSuspectActualLRPArgsForCall []struct {
+		arg1 context.Context
+		arg2 lager.Logger
+		arg3 string
+		arg4 int32
+	}
+	promoteSuspectActualLRPReturns struct {
+		result1 *models.ActualLRP
+		result2 *models.ActualLRP
+		result3 *models.ActualLRP
+		result4 error
+	}
+	promoteSuspectActualLRPReturnsOnCall map[int]struct {
+		result1 *models.ActualLRP
+		result2 *models.ActualLRP
+		result3 *models.ActualLRP
+		result4 error
+	}
 	RemoveSuspectActualLRPStub        func(context.Context, lager.Logger, *models.ActualLRPKey) (*models.ActualLRP, error)
 	removeSuspectActualLRPMutex       sync.RWMutex
 	removeSuspectActualLRPArgsForCall []struct {
@@ -28,6 +48,79 @@ type FakeSuspectDB struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeSuspectDB) PromoteSuspectActualLRP(arg1 context.Context, arg2 lager.Logger, arg3 string, arg4 int32) (*models.ActualLRP, *models.ActualLRP, *models.ActualLRP, error) {
+	fake.promoteSuspectActualLRPMutex.Lock()
+	ret, specificReturn := fake.promoteSuspectActualLRPReturnsOnCall[len(fake.promoteSuspectActualLRPArgsForCall)]
+	fake.promoteSuspectActualLRPArgsForCall = append(fake.promoteSuspectActualLRPArgsForCall, struct {
+		arg1 context.Context
+		arg2 lager.Logger
+		arg3 string
+		arg4 int32
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.PromoteSuspectActualLRPStub
+	fakeReturns := fake.promoteSuspectActualLRPReturns
+	fake.recordInvocation("PromoteSuspectActualLRP", []interface{}{arg1, arg2, arg3, arg4})
+	fake.promoteSuspectActualLRPMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3, ret.result4
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
+}
+
+func (fake *FakeSuspectDB) PromoteSuspectActualLRPCallCount() int {
+	fake.promoteSuspectActualLRPMutex.RLock()
+	defer fake.promoteSuspectActualLRPMutex.RUnlock()
+	return len(fake.promoteSuspectActualLRPArgsForCall)
+}
+
+func (fake *FakeSuspectDB) PromoteSuspectActualLRPCalls(stub func(context.Context, lager.Logger, string, int32) (*models.ActualLRP, *models.ActualLRP, *models.ActualLRP, error)) {
+	fake.promoteSuspectActualLRPMutex.Lock()
+	defer fake.promoteSuspectActualLRPMutex.Unlock()
+	fake.PromoteSuspectActualLRPStub = stub
+}
+
+func (fake *FakeSuspectDB) PromoteSuspectActualLRPArgsForCall(i int) (context.Context, lager.Logger, string, int32) {
+	fake.promoteSuspectActualLRPMutex.RLock()
+	defer fake.promoteSuspectActualLRPMutex.RUnlock()
+	argsForCall := fake.promoteSuspectActualLRPArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeSuspectDB) PromoteSuspectActualLRPReturns(result1 *models.ActualLRP, result2 *models.ActualLRP, result3 *models.ActualLRP, result4 error) {
+	fake.promoteSuspectActualLRPMutex.Lock()
+	defer fake.promoteSuspectActualLRPMutex.Unlock()
+	fake.PromoteSuspectActualLRPStub = nil
+	fake.promoteSuspectActualLRPReturns = struct {
+		result1 *models.ActualLRP
+		result2 *models.ActualLRP
+		result3 *models.ActualLRP
+		result4 error
+	}{result1, result2, result3, result4}
+}
+
+func (fake *FakeSuspectDB) PromoteSuspectActualLRPReturnsOnCall(i int, result1 *models.ActualLRP, result2 *models.ActualLRP, result3 *models.ActualLRP, result4 error) {
+	fake.promoteSuspectActualLRPMutex.Lock()
+	defer fake.promoteSuspectActualLRPMutex.Unlock()
+	fake.PromoteSuspectActualLRPStub = nil
+	if fake.promoteSuspectActualLRPReturnsOnCall == nil {
+		fake.promoteSuspectActualLRPReturnsOnCall = make(map[int]struct {
+			result1 *models.ActualLRP
+			result2 *models.ActualLRP
+			result3 *models.ActualLRP
+			result4 error
+		})
+	}
+	fake.promoteSuspectActualLRPReturnsOnCall[i] = struct {
+		result1 *models.ActualLRP
+		result2 *models.ActualLRP
+		result3 *models.ActualLRP
+		result4 error
+	}{result1, result2, result3, result4}
 }
 
 func (fake *FakeSuspectDB) RemoveSuspectActualLRP(arg1 context.Context, arg2 lager.Logger, arg3 *models.ActualLRPKey) (*models.ActualLRP, error) {
@@ -99,6 +192,8 @@ func (fake *FakeSuspectDB) RemoveSuspectActualLRPReturnsOnCall(i int, result1 *m
 func (fake *FakeSuspectDB) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.promoteSuspectActualLRPMutex.RLock()
+	defer fake.promoteSuspectActualLRPMutex.RUnlock()
 	fake.removeSuspectActualLRPMutex.RLock()
 	defer fake.removeSuspectActualLRPMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/db/sqldb/suspect_db_test.go
+++ b/db/sqldb/suspect_db_test.go
@@ -34,6 +34,103 @@ var _ = Describe("Suspect ActualLRPs", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	Describe("PromoteSuspectActualLRP", func() {
+		Context("when gettting suspect LRP fails", func() {
+			It("returns an error", func() {
+				_, _, _, err := sqlDB.PromoteSuspectActualLRP(ctx, logger, actualLRP.ProcessGuid, actualLRP.Index)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(models.ErrResourceNotFound))
+			})
+
+			Context("when there is an ordinary actualLRP with the same key", func() {
+				var (
+					replacementLRP   *models.ActualLRP
+					replacementGuid  string
+					replacementIndex int32
+				)
+
+				BeforeEach(func() {
+					replacementGuid = "some-other-guid"
+					replacementIndex = int32(0)
+					replacementLRP = model_helpers.NewValidActualLRP(replacementGuid, replacementIndex)
+					replacementLRP.CrashCount = 0
+					replacementLRP.CrashReason = ""
+					replacementLRP.Since = fakeClock.Now().UnixNano()
+					replacementLRP.ModificationTag = models.ModificationTag{}
+					replacementLRP.ModificationTag.Increment()
+					replacementLRP.ModificationTag.Increment()
+					replacementLRP.MetricTags = nil
+					_, err := sqlDB.CreateUnclaimedActualLRP(ctx, logger, &replacementLRP.ActualLRPKey)
+					Expect(err).NotTo(HaveOccurred())
+					_, _, err = sqlDB.ClaimActualLRP(ctx, logger, replacementGuid, replacementIndex, &replacementLRP.ActualLRPInstanceKey)
+					Expect(err).NotTo(HaveOccurred())
+					_, _, err = sqlDB.StartActualLRP(ctx, logger, &replacementLRP.ActualLRPKey, &replacementLRP.ActualLRPInstanceKey, &replacementLRP.ActualLRPNetInfo, model_helpers.NewActualLRPInternalRoutes(), nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("does not remove the ordinary actual LRP", func() {
+					beforeLRPs, err := sqlDB.ActualLRPs(ctx, logger, models.ActualLRPFilter{ProcessGuid: replacementGuid, Index: &replacementIndex})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(beforeLRPs).To(ConsistOf(replacementLRP))
+
+					_, _, removedLRP, err := sqlDB.PromoteSuspectActualLRP(ctx, logger, replacementLRP.ProcessGuid, replacementLRP.Index)
+					Expect(err).To(HaveOccurred())
+					Expect(removedLRP).To(BeNil())
+
+					afterLRPs, err := sqlDB.ActualLRPs(ctx, logger, models.ActualLRPFilter{ProcessGuid: replacementGuid, Index: &replacementIndex})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(afterLRPs).To(ConsistOf(replacementLRP))
+				})
+			})
+		})
+
+		Context("when there is a suspect actualLRP", func() {
+			BeforeEach(func() {
+				queryStr := "UPDATE actual_lrps SET presence = ? WHERE process_guid = ? AND instance_index = ? AND presence = ?"
+				if test_helpers.UsePostgres() {
+					queryStr = test_helpers.ReplaceQuestionMarks(queryStr)
+				}
+				_, err := db.ExecContext(ctx, queryStr, models.ActualLRP_Suspect, actualLRP.ProcessGuid, actualLRP.Index, models.ActualLRP_Ordinary)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			Context("when there is an ordinary actualLRP with the same key", func() {
+				BeforeEach(func() {
+					replacementLRP := model_helpers.NewValidActualLRP(guid, index)
+					_, err := sqlDB.CreateUnclaimedActualLRP(ctx, logger, &replacementLRP.ActualLRPKey)
+					Expect(err).NotTo(HaveOccurred())
+					_, _, err = sqlDB.ClaimActualLRP(ctx, logger, guid, index, &replacementLRP.ActualLRPInstanceKey)
+					Expect(err).NotTo(HaveOccurred())
+					_, _, err = sqlDB.StartActualLRP(ctx, logger, &replacementLRP.ActualLRPKey, &replacementLRP.ActualLRPInstanceKey, &replacementLRP.ActualLRPNetInfo, model_helpers.NewActualLRPInternalRoutes(), nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("removes the ordinary actual LRP", func() {
+					beforeLRPs, err := sqlDB.ActualLRPs(ctx, logger, models.ActualLRPFilter{ProcessGuid: guid, Index: &index})
+					Expect(err).NotTo(HaveOccurred())
+
+					beforeLRP, afterLRP, removedLRP, err := sqlDB.PromoteSuspectActualLRP(ctx, logger, actualLRP.ProcessGuid, actualLRP.Index)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(beforeLRPs).To(ConsistOf(removedLRP, beforeLRP))
+
+					afterLRPs, err := sqlDB.ActualLRPs(ctx, logger, models.ActualLRPFilter{ProcessGuid: guid, Index: &index})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(afterLRPs).To(ConsistOf(afterLRP))
+				})
+			})
+
+			It("promotes suspect LRP to ordinary", func() {
+				_, afterLRP, _, err := sqlDB.PromoteSuspectActualLRP(ctx, logger, actualLRP.ProcessGuid, actualLRP.Index)
+				Expect(err).NotTo(HaveOccurred())
+
+				afterLRPs, err := sqlDB.ActualLRPs(ctx, logger, models.ActualLRPFilter{ProcessGuid: guid, Index: &index})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(afterLRPs).To(ConsistOf(afterLRP))
+				Expect(afterLRP.Presence).To(Equal(models.ActualLRP_Ordinary))
+			})
+		})
+	})
+
 	Describe("RemoveSuspectActualLRP", func() {
 		Context("when there is a suspect actualLRP", func() {
 			BeforeEach(func() {

--- a/db/suspect_db.go
+++ b/db/suspect_db.go
@@ -11,4 +11,5 @@ import (
 
 type SuspectDB interface {
 	RemoveSuspectActualLRP(context.Context, lager.Logger, *models.ActualLRPKey) (*models.ActualLRP, error)
+	PromoteSuspectActualLRP(ctx context.Context, logger lager.Logger, processGuid string, index int32) (*models.ActualLRP, *models.ActualLRP, *models.ActualLRP, error)
 }


### PR DESCRIPTION
### What is this change about?

BBS convergence is prone to race condition since it collects keys that may become stale during convergence cycle.

When Suspect cell comes back up and SuspectKeysWithExistingCells gets populated some suspect LRPs might have replacement scheduled. When replacement LRP starts StartActualLRP will remove suspect LRP from database.

### What problem it is trying to solve?

When Suspect LRP is replaced by Ordinary LRP and Suspect cell comes back up the following events occur:

1. [StartActualLRP from Suspect LRP is ignored](https://github.com/cloudfoundry/bbs/blob/0eae9414b1d5f5183ca1540656c27092a4959814/controllers/actual_lrp_lifecycle_controller.go#L117) `bbs.request.start-actual-lrp.ignored-start-request-from-suspect`
2. [StartActualLRP from Ordinary LRP succeeds and Suspect LRP is removed](https://github.com/cloudfoundry/bbs/blob/0eae9414b1d5f5183ca1540656c27092a4959814/controllers/actual_lrp_lifecycle_controller.go#L149)
3. [actual_lrp_instance_removed is emitted for removed Suspect LRP](https://github.com/cloudfoundry/bbs/blob/0eae9414b1d5f5183ca1540656c27092a4959814/controllers/actual_lrp_lifecycle_controller.go#L153)
4. NCP releases IP address that belonged to Suspect LRP
5. Convergence has stale state of keys (before Suspect LRP is removed) and [it removes Ordinary LRP](https://github.com/cloudfoundry/bbs/blob/0eae9414b1d5f5183ca1540656c27092a4959814/controllers/lrp_convergence_controller.go#L263)
6. As you see in the code no events were emitted for removal of Ordinary LRP
7. Then convergence tries to promote Suspect LRP to Ordinary, but since Suspect LRP is no longer in database (step 2) it fails:
```
{"error":"the requested resource could not be found","from":"SUSPECT","key":{"process_guid":"0e7a7d91-0650-4cf9-a377-6ea6a8aec42f-7bb413fe-7c45-4022-894d-4e1b32d31077","index":2,"domain":"cf-apps"},"session":"7111428.383.2","to":"ORDINARY"}
```
8. At the end of this cycle we have no LRPs in database for this key.
9. Next, [StartActualLRP from Suspect LRP succeeds since it is not registered in database as Suspect.](https://github.com/cloudfoundry/bbs/blob/0eae9414b1d5f5183ca1540656c27092a4959814/controllers/actual_lrp_lifecycle_controller.go#LL116C1-L116C1) 
10. Suspect LRP becomes Ordinary and container keeps running with IP that was released and potentially reserved by another container by NCP.
11. StartActualLRP from another Ordinary LRP fails because [there is already an LRP with the same process guid, index, presence but different instance guid](https://github.com/cloudfoundry/bbs/blob/0eae9414b1d5f5183ca1540656c27092a4959814/models/actual_lrp.go#L166)

So now, on step (5) Ordinary LRP will only be removed if there is a suspect LRP checked in the same transaction.

### How should this change be described in diego-release release notes?

Fix convergence race condition for suspect LRPs when replacement has been started.

### Please provide any contextual information.

https://vmware.slack.com/archives/C01ERQAVD2L/p1686850075552959

### Tag your pair, your PM, and/or team!

@geofffranks 

Thank you!
