### PR TITLE
Make BBS DesiredLRPHandler send the Stop/Update LRP requests to rep in parallel

### DIFF
--- a/handlers/desired_lrp_handlers.go
+++ b/handlers/desired_lrp_handlers.go
@@ -402,10 +402,12 @@ func (h *DesiredLRPHandler) stopInstancesFrom(ctx context.Context, logger lager.
 						continue
 					}
 					logger.Debug("stopping-lrp-instance")
-					err = repClient.StopLRPInstance(logger, lrp.ActualLRPKey, lrp.ActualLRPInstanceKey)
-					if err != nil {
-						logger.Error("failed-stopping-lrp-instance", err)
-					}
+					go func() {
+						err := repClient.StopLRPInstance(logger, lrp.ActualLRPKey, lrp.ActualLRPInstanceKey)
+						if err != nil {
+							logger.Error("failed-stopping-lrp-instance", err)
+						}
+					} ()
 				}
 			}
 		}
@@ -458,10 +460,12 @@ func (h *DesiredLRPHandler) updateInstances(ctx context.Context, logger lager.Lo
 			}
 
 			lrpUpdate := rep.NewLRPUpdate(lrp.ActualLRPInstanceKey.InstanceGuid, lrp.ActualLRPKey, internalRoutes, metricTags)
-			err = repClient.UpdateLRPInstance(logger, lrpUpdate)
-			if err != nil {
-				logger.Error("updating-lrp-instance", err)
-			}
+			go func() {
+				err := repClient.UpdateLRPInstance(logger, lrpUpdate)
+				if err != nil {
+					logger.Error("updating-lrp-instance", err)
+				}
+			} ()
 		}
 	}
 }


### PR DESCRIPTION
### What is this change about?

Make the Desired LRP Handler of BBS send the `update` and `stop` requests to `rep` in parallel and not in sequence. In either case, the response is just dumped in the logs and no specific action is done if there is a failure.

### What problem it is trying to solve?

When the DesiredLRP handler is sending `update` or `stop` in some cases, they may get blocked in the `rep`, and thus the overall time for completing the respective request to rise to more than a minute. With this change, the overall time does not change based on the current status of the `rep` and what it is doing.

### What is the impact if the change is not made?

Monitoring response times of the BBS is a good metric to check it's health and whether scaling up or configuration change is needed. The Cloud Controller and REP both do request to BBS with a certain timeout and retries configuration, and requests that take abnormally long time make the analysis of those metrics harder.

### How should this change be described in diego-release release notes?

Make BBS DesiredLRPHandler send the Stop/Update LRP requests to `rep` in parallel

### Please provide any contextual information.

We have been able to reproduce this with the following test on a landscape with 100 diego-cells
```
cf push xxx -o vlast3k/spring-music:big2 -u process -k 4g
cf scale xxx -i 100
```
at this point, stop the CC CLI output (if for some reason it is waiting) using Ctrl-C, and then immediately scale down
```
scale xxx -i 1
```
Then, when looking at the BBS Request Latency, a request that is 30+ seconds will be observed.

----

The reason is that, when the scale up requests is received by all the `rep`s, they start downloading the docker image (which is 2g), and this takes some time. While the image is being downloaded, there is a lock and for this LRP nothing else can be done, no stopping, no update. When an Update or Stop requests comes to do something about the LRP, it needs to first retrieve the lock, and it is released only once the download is finished.

It takes 30-60 seconds to complete the download on each of the 100 `rep`s.
During this time, the BBS is sequentially calling `repClient.UpdateLRPInstance` or `repClient.StopLRPInstance`. The timeout is set to 10s, so some of the calls are delayed for 10s, and then failed. And then again and again, until all reps have managed to download the image

---

Note for the update to the tests.

They needed some tweaking, as the way they were implemented, was that they were relying on the fact  that the methods are executed sequentially. They are all testing functionality unrelated to the parallel execution, so adding a small delay after the trigger to BBS to start the Update, helped to bring the state in the expected form. Yet some of them were particularly picky in the order the requests are sent (which they should not). Others wanted to do something or count invocations, which with parallel calls has to be done with the `atomic` package to get stable results

### Tag your pair, your PM, and/or team!

@PlamenDoychev 

Thank you!
