### PR TITLE
Fix issue with go vet/go mod

### DIFF
--- a/models/metric_tags.go
+++ b/models/metric_tags.go
@@ -37,7 +37,7 @@ func (v MetricTagValue_DynamicValue) Valid() bool {
 	}
 }
 
-func ConvertMetricTags(metricTags map[string]*MetricTagValue, info map[MetricTagValue_DynamicValue]any) (map[string]string, error) {
+func ConvertMetricTags(metricTags map[string]*MetricTagValue, info map[MetricTagValue_DynamicValue]interface{}) (map[string]string, error) {
 	tags := make(map[string]string)
 	for k, v := range metricTags {
 		if v.Dynamic > 0 {


### PR DESCRIPTION
Our way of `go mod`ing our Diego release introducing issues with blank `go.mod` files that results the imports having to default to go 1.16 when running `go vet`.  This causes issues using the `any` keyword in replacing `interface{}`.

This commit reverts the change made in https://github.com/cloudfoundry/bbs/pull/77