### PR TITLE
Fix pgx/v5 connection string parsing

### DIFF
--- a/db/sqldb/helpers/connection_string.go
+++ b/db/sqldb/helpers/connection_string.go
@@ -11,7 +11,6 @@ import (
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/go-sql-driver/mysql"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
@@ -74,7 +73,7 @@ func addTLSParams(
 		}
 		databaseConnectionString = cfg.FormatDSN()
 	case "postgres":
-		config, err := pgconn.ParseConfig(databaseConnectionString)
+		config, err := pgx.ParseConfig(databaseConnectionString)
 		if err != nil {
 			logger.Fatal("invalid-db-connection-string", err, lager.Data{"connection-string": databaseConnectionString})
 		}
@@ -82,9 +81,7 @@ func addTLSParams(
 		tlsConfig := generateTLSConfig(logger, sqlCACertFile, sqlEnableIdentityVerification)
 		config.TLSConfig = tlsConfig
 
-		connConfig := &pgx.ConnConfig{Config: *config}
-		return connConfig.ConnString()
-
+		databaseConnectionString = config.ConnString()
 	default:
 		logger.Fatal("invalid-driver-name", nil, lager.Data{"driver-name": driverName})
 	}


### PR DESCRIPTION
### What is this change about?

- Follow up commit to https://github.com/cloudfoundry/bbs/pull/84

- We don't need to use the `pgconn` package and can instead just use the main `pgx` package


### What problem it is trying to solve?

Should resolve bug:
```
[o]locket] {"timestamp":"1710441111.868907213","source":"locket","message":"locket.sql-failed-to-connect","log_level":3,"data":{"error":"failed to connect to `host=/var/run/postgresql user=root database=`: server error (FATAL: role \"root\" does not exist (SQLSTATE 28000))","trace":"goroutine 1 [running]:\ncode.cloudfoundry.org/lager/v3.(*logger).Fatal(0xc0002b0a10, {0x11e7228, 0x15}, {0x133ef80?, 0xc000322900}, {0x0, 0x0, 0x0?})\n\t/tmp/build/11027783/repo/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/v3/logger.go:166 +0x2e5\nmain.main()\n\t/tmp/build/11027783/repo/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/locket/cmd/locket/main.go:75 +0x463\n"}}
[e]locket] panic: failed to connect to `host=/var/run/postgresql user=root database=`: server error (FATAL: role "root" does not exist (SQLSTATE 28000))
```
As the postgres config is present but not being consumed correctly.

### What is the impact if the change is not made?

Tests stay red and we never ship again. Also compatibility with postgres will never happen.

### How should this change be described in diego-release release notes?

N/A
