### PR TITLE
Fix issue with Database plan caching for migraton tests

### DIFF
--- a/db/migrations/migrations_suite_test.go
+++ b/db/migrations/migrations_suite_test.go
@@ -105,6 +105,11 @@ func listTableNames(db *sql.DB) []string {
 
 func getTableSchema(db *sql.DB, tableName string) []*sql.ColumnType {
 	rows, err := db.Query("SELECT * FROM " + tableName)
+
+	//retry if failing https://github.com/jackc/pgx/issues/927
+	if err != nil {
+		rows, err = db.Query("SELECT * FROM " + tableName)
+	}
 	Expect(err).NotTo(HaveOccurred())
 	columnTypes, err := rows.ColumnTypes()
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Fixing issue with database caching statements under pgx, this fix just attempts a retry as it clears out the statement cache on error.

More info
https://github.com/jackc/pgx/issues/927