### PR TITLE
Split destinations by commas to handle comma-delimited lists

### DIFF
--- a/models/security_groups.go
+++ b/models/security_groups.go
@@ -109,7 +109,12 @@ func (rule SecurityGroupRule) validateDestinations() error {
 
 	var validationError ValidationError
 
+	var destinations []string
 	for _, d := range rule.Destinations {
+		destinations = append(destinations, strings.Split(d, ",")...)
+	}
+
+	for _, d := range destinations {
 		n := strings.IndexAny(d, "-/")
 		if n == -1 {
 			if net.ParseIP(d) == nil {

--- a/models/security_groups_test.go
+++ b/models/security_groups_test.go
@@ -167,6 +167,7 @@ var _ = Describe("SecurityGroupRule", func() {
 						Expect(validationErr).To(MatchError(ContainSubstring("destination")))
 					})
 				})
+
 			})
 		}
 
@@ -255,6 +256,16 @@ var _ = Describe("SecurityGroupRule", func() {
 			Context("when its a CIDR", func() {
 				BeforeEach(func() {
 					destination = "8.8.8.8/16"
+				})
+
+				It("passes validation and does not return an error", func() {
+					Expect(validationErr).NotTo(HaveOccurred())
+				})
+			})
+
+			Context("when it's a comma-delimited list of ips", func() {
+				BeforeEach(func() {
+					destination = "1.2.3.4,5.6.7.8"
 				})
 
 				It("passes validation and does not return an error", func() {


### PR DESCRIPTION
When a user of CF defines an ASG, it is usually of the form:
```
[
  {
    "protocol": "tcp",
    "destination": "10.0.10.0/24",
    "ports": "80,443",
    "log": true,
    "description": "Allow http and https traffic to ZoneA"
  },
 {
    "protocol": "tcp",
    "destination": "10.0.20.0/24",
    "ports": "80,443",
    "log": true,
    "description": "Allow http and https traffic to ZoneB"
  }
]
```

This commit will allow users to define the `destinations` with comma-delimited lists, allowing the previous ASG to be condensed to:

```
[
  {
    "protocol": "tcp",
    "destination": "10.0.10.0/24,10.0.20.0/24", 👈 🥳
    "ports": "80,443",
    "log": true,
    "description": "Allow http and https traffic to ZoneA and ZoneB"
  }
]
```


[#186770285](https://www.pivotaltracker.com/story/show/186770285)