### PR TITLE
Check for all types of errors when fetchingTasks to prevent panics

### DIFF
--- a/db/sqldb/task_db.go
+++ b/db/sqldb/task_db.go
@@ -458,13 +458,18 @@ func (db *SQLDB) fetchTasks(ctx context.Context, logger lager.Logger, rows *sql.
 		var guid string
 
 		task, guid, err = db.fetchTaskInternal(logger, rows)
-		if err == models.ErrDeserialize {
-			invalidGuids = append(invalidGuids, guid)
+		if err != nil {
+			if err == models.ErrDeserialize {
+				invalidGuids = append(invalidGuids, guid)
+			}
+
 			if abortOnError {
 				break
 			}
+
 			continue
 		}
+
 		tasks = append(tasks, task)
 		validGuids = append(validGuids, task.TaskGuid)
 	}


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
We are only checking for one type of error. If we get another type of error, then it panics. We don't like panics.

Backward Compatibility
---------------
Breaking Change? No
