### PR TITLE
Increase start timeout for BBS tests

### DIFF
--- a/cmd/bbs/testrunner/runner.go
+++ b/cmd/bbs/testrunner/runner.go
@@ -28,7 +28,7 @@ func New(binPath string, bbsConfig config.BBSConfig) *ginkgomon.Runner {
 		Name:              "bbs",
 		Command:           exec.Command(binPath, "-config", f.Name()),
 		StartCheck:        "bbs.started",
-		StartCheckTimeout: 20 * time.Second,
+		StartCheckTimeout: 1 * time.Minute,
 		Cleanup: func() {
 			// do not use Expect otherwise a race condition will happen
 			os.RemoveAll(f.Name())


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
It seems like 20s not enough time to run migrations on mysql 8



Backward Compatibility
---------------
Breaking Change? **No**
