### PR TITLE
ignore false positive on G407

### DIFF
--- a/encryption/crypt.go
+++ b/encryption/crypt.go
@@ -72,5 +72,6 @@ func (d *cryptor) Decrypt(encrypted Encrypted) ([]byte, error) {
 		return nil, fmt.Errorf("Unable to create GCM-wrapped cipher: %q", err)
 	}
 
+	// #nosec G407 - G407 is incorrectly flagging Decrypt calls that use the nonce provided in the encrypted data. we randomize this for encryption, which is where it matters. https://github.com/securego/gosec/issues/1209
 	return aead.Open(nil, encrypted.Nonce, encrypted.CipherText, nil)
 }


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Ignores gosec's broken G407 rule that is incorrectly flagging our derypt calls: https://github.com/securego/gosec/issues/1209


Backward Compatibility
---------------
Breaking Change? no