### PR TITLE
Remove old property: locks.locket.enabled - Diego release

### DIFF
--- a/cmd/bbs/config/config_test.go
+++ b/cmd/bbs/config/config_test.go
@@ -50,7 +50,6 @@ var _ = Describe("BBSConfig", func() {
 			"listen_address": "0.0.0.0:8889",
 			"lock_retry_interval": "5s",
 			"lock_ttl": "15s",
-			"locks_locket_enabled": true,
 			"locket_address": "127.0.0.1:18018",
 			"locket_ca_cert_file": "locket-ca-cert",
 			"locket_client_cert_file": "locket-client-cert",


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Remove old property: locks.locket.enabled - Diego release

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
