### PR TITLE
Update staticcheck comments with latest version

### DIFF
--- a/handlers/actual_lrp_handlers_test.go
+++ b/handlers/actual_lrp_handlers_test.go
@@ -410,9 +410,7 @@ var _ = Describe("ActualLRP Handlers", func() {
 
 				//lint:ignore SA1019 - calling deprecated model while unit testing deprecated method
 				actualLRPGroups = []*models.ActualLRPGroup{
-					//lint:ignore SA1019 - calling deprecated model while unit testing deprecated method
 					{Instance: &actualLRP1},
-					//lint:ignore SA1019 - calling deprecated model while unit testing deprecated method
 					{Instance: &actualLRP2, Evacuating: &evacuatingLRP2},
 				}
 			})
@@ -548,8 +546,8 @@ var _ = Describe("ActualLRP Handlers", func() {
 			var actualLRPGroups []*models.ActualLRPGroup
 
 			BeforeEach(func() {
-				actualLRPGroups = //lint:ignore SA1019 - deprecated model used for testing deprecated functionality
-					[]*models.ActualLRPGroup{
+				actualLRPGroups =
+					[]*models.ActualLRPGroup{ //lint:ignore SA1019 - deprecated model used for testing deprecated functionality
 						{Instance: &actualLRP1},
 						{Instance: &actualLRP2, Evacuating: &evacuatingLRP2},
 					}


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Update staticcheck comments with latest version

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
