### PR TITLE
Log Client Certificate Identity Information in Access Logs

### DIFF
--- a/handlers/middleware/middleware.go
+++ b/handlers/middleware/middleware.go
@@ -21,11 +21,26 @@ type Emitter interface {
 
 func LogWrap(logger, accessLogger lager.Logger, loggableHandlerFunc LoggableHandlerFunc) http.HandlerFunc {
 	lagerDataFromReq := func(r *http.Request) lager.Data {
-		return lager.Data{
+		lagerData := lager.Data{
 			"method":      r.Method,
 			"remote_addr": r.RemoteAddr,
 			"request":     r.URL.String(),
 		}
+
+		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+			indexLeafCertConnectionIsVerifiedAgainst := 0 // see also https://github.com/golang/go/blob/e929fb78e47dc191a402d34ca949d2e0c67e31b8/src/crypto/tls/common.go#L281-L282
+			cert := r.TLS.PeerCertificates[indexLeafCertConnectionIsVerifiedAgainst]
+
+			lagerData["peer_cert_subject_common_name"] = cert.Subject.CommonName
+			lagerData["peer_cert_subject_organizational_unit"] = cert.Subject.OrganizationalUnit
+			lagerData["peer_cert_subject_organization"] = cert.Subject.Organization
+
+			lagerData["peer_cert_issuer_common_name"] = cert.Issuer.CommonName
+			lagerData["peer_cert_issuer_organizational_unit"] = cert.Issuer.OrganizationalUnit
+			lagerData["peer_cert_issuer_organization"] = cert.Issuer.Organization
+		}
+
+		return lagerData
 	}
 
 	if accessLogger != nil {

--- a/handlers/middleware/middleware_test.go
+++ b/handlers/middleware/middleware_test.go
@@ -2,6 +2,9 @@ package middleware_test
 
 import (
 	"code.cloudfoundry.org/bbs/cmd/bbs/config"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"net/http"
 	"time"
 
@@ -307,6 +310,42 @@ var _ = Describe("Test Middleware", func() {
 				Expect(accessLogger.Buffer()).To(gbytes.Say("method\":\"GET\""))
 				Expect(accessLogger.Buffer()).To(gbytes.Say("remote_addr\":\"127.0.0.1:8080\""))
 				Expect(accessLogger.Buffer()).To(gbytes.Say("request\":\"http://example.com\""))
+			})
+
+			When("request has TLS peer certificates", func() {
+				BeforeEach(func() {
+					handler := middleware.LogWrap(logger, accessLogger, loggableHandlerFunc)
+					req, err := http.NewRequest("GET", "http://example.com", nil)
+					Expect(err).NotTo(HaveOccurred())
+					req.RemoteAddr = "127.0.0.1:8080"
+					req.TLS = &tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{
+							{
+								Subject: pkix.Name{
+									CommonName:         "subject-cn",
+									OrganizationalUnit: []string{"subject-ou"},
+									Organization:       []string{"subject-o"},
+								},
+								Issuer: pkix.Name{
+									CommonName:         "issuer-cn",
+									OrganizationalUnit: []string{"issuer-ou"},
+									Organization:       []string{"issuer-o"},
+								},
+							},
+						},
+					}
+
+					handler.ServeHTTP(nil, req)
+				})
+
+				It("logs peer certificate information", func() {
+					Expect(logger.Buffer()).To(gbytes.Say("peer_cert_subject_common_name\":\"subject-cn\""))
+					Expect(logger.Buffer()).To(gbytes.Say("peer_cert_subject_organization\":\\[\"subject-o\"\\]"))
+					Expect(logger.Buffer()).To(gbytes.Say("peer_cert_subject_organizational_unit\":\\[\"subject-ou\"\\]"))
+					Expect(logger.Buffer()).To(gbytes.Say("peer_cert_issuer_common_name\":\"issuer-cn\""))
+					Expect(logger.Buffer()).To(gbytes.Say("peer_cert_issuer_organization\":\\[\"issuer-o\"\\]"))
+					Expect(logger.Buffer()).To(gbytes.Say("peer_cert_issuer_organizational_unit\":\\[\"issuer-ou\"\\]"))
+				})
 			})
 		})
 	})

--- a/handlers/middleware/middleware_test.go
+++ b/handlers/middleware/middleware_test.go
@@ -315,7 +315,7 @@ var _ = Describe("Test Middleware", func() {
 			When("request has TLS peer certificates", func() {
 				BeforeEach(func() {
 					accessLogger = lagertest.NewTestLogger("")
-					accessLogger.RegisterSink(lager.NewWriterSink(GinkgoWriter, lager.INFO))
+					accessLogger.RegisterSink(lager.NewWriterSink(GinkgoWriter, lager.INFO)) // peer cert information should be logged at INFO level
 
 					handler := middleware.LogWrap(logger, accessLogger, loggableHandlerFunc)
 					req, err := http.NewRequest("", "", nil)

--- a/handlers/middleware/middleware_test.go
+++ b/handlers/middleware/middleware_test.go
@@ -314,10 +314,12 @@ var _ = Describe("Test Middleware", func() {
 
 			When("request has TLS peer certificates", func() {
 				BeforeEach(func() {
+					accessLogger = lagertest.NewTestLogger("")
+					accessLogger.RegisterSink(lager.NewWriterSink(GinkgoWriter, lager.INFO))
+
 					handler := middleware.LogWrap(logger, accessLogger, loggableHandlerFunc)
-					req, err := http.NewRequest("GET", "http://example.com", nil)
+					req, err := http.NewRequest("", "", nil)
 					Expect(err).NotTo(HaveOccurred())
-					req.RemoteAddr = "127.0.0.1:8080"
 					req.TLS = &tls.ConnectionState{
 						PeerCertificates: []*x509.Certificate{
 							{


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Problem
---------------
BBS currently does not include TLS peer certificate information in its access logs, making it difficult to reliably identify authenticated clients. At the moment, only the client IP address is logged, while no certificate-based identity information about the caller is recorded.

https://github.com/cloudfoundry/bbs/blob/e5644ae7617bf1a534cb7f2850ce5b57b580b26c/handlers/middleware/middleware.go#L26

Solution
---------------
This PR enhances the `LogWrap` middleware to include TLS peer certificate information in request logs whenever such information is available.

If an access logger is configured via `access_log_path`, the TLS peer certificate details are logged at the `INFO` level and therefore written to the access log.

Backward Compatibility
---------------
Breaking Change? **No**


Contact Me
---------------
Feel free to reach out directly via Slack: https://cloudfoundry.slack.com/team/U0578H2V37D