### PR TITLE
bbs: update metron-down test for non-blocking loggregator dial (tnz-96145)

### DIFF
--- a/cmd/bbs/main_test.go
+++ b/cmd/bbs/main_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/tedsuo/ifrit"
+	ginkgomon "github.com/tedsuo/ifrit/ginkgomon_v2"
 )
 
 var _ = Describe("BBS main test", func() {
@@ -29,9 +30,12 @@ var _ = Describe("BBS main test", func() {
 			testIngressServer.Stop()
 		})
 
-		It("exit with non-zero status code", func() {
-			bbsProcess = ifrit.Background(bbsRunner)
-			Eventually(bbsProcess.Wait()).Should(Receive(HaveOccurred()))
+		// diego-logging-client now dials loggregator non-blocking (lazy). bbs
+		// starts successfully and retries the connection in the background, so
+		// it must NOT exit when metron is temporarily unavailable.
+		It("starts successfully and does not exit", func() {
+			bbsProcess = ginkgomon.Invoke(bbsRunner)
+			Consistently(bbsProcess.Wait()).ShouldNot(Receive())
 		})
 	})
 })


### PR DESCRIPTION
## Summary
diego-logging-client [tnz-96145](https://github.com/cloudfoundry/diego-logging-client/pull/XXX) removed grpc.WithBlock() and grpc.WithTimeout(1s) from NewIngressClient, making the Loggregator v2 gRPC connection non-blocking. Instead of failing at startup if the loggregator agent is unavailable, BBS now establishes the connection lazily in the background and retries automatically.

Prior to this change, BBS would exit with a non-zero status code within ~1 second of startup if metron_agent was not yet listening. During BOSH rolling upgrades, metron_agent can be briefly unavailable while its VM is being updated, causing BBS to crash-restart unnecessarily.

After this change, BBS starts successfully regardless of metron availability. Log emissions are queued and delivered once the connection is established. This matches the intended resilience improvement from tnz-96145.

The test "when the metron agent isn't up → exit with non-zero status code" was asserting the old blocking-dial behaviour. This PR updates it to assert the new correct behaviour: BBS starts and keeps running when metron is temporarily unavailable.

## What changed
cmd/bbs/main_test.go — replaced Eventually(process.Wait()).Should(Receive(HaveOccurred())) with Consistently(process.Wait()).ShouldNot(Receive()) and updated the description from "exit with non-zero status code" to "starts successfully and does not exit".

## Backward Compatibility
Breaking Change? No

This is a test-only change. No production behaviour is modified. The test now correctly reflects the actual behaviour of BBS after the diego-logging-client non-blocking dial change.