### PR TITLE
Preserve TaskStartRequest wire format across the auctioneer alias move

### DIFF
--- a/models/auctioneer_types.go
+++ b/models/auctioneer_types.go
@@ -4,6 +4,7 @@ package models
 // to break the bbs <-> auctioneer module cycle.
 
 import (
+	"encoding/json"
 	"errors"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -39,6 +40,25 @@ func NewTaskStartRequestFromModel(taskGuid, domain string, taskDef *TaskDefiniti
 			NewPlacementConstraint(taskDef.RootFs, taskDef.PlacementTags, volumeMounts),
 		),
 	}
+}
+
+// MarshalJSON flattens TaskStartRequest to the shape of its wrapped
+// SchedulingTask. Before this type moved here from auctioneer, it
+// anonymously embedded rep.Task, so its fields were promoted to the top
+// level of the JSON object on the wire. Task became a named field in the
+// move, which nested the payload under a "Task" key instead -- silently
+// breaking auctions between an old auctioneer and a new BBS (or vice
+// versa) during a rolling deploy, since the old side never finds its
+// fields and drops every request with an empty-guid validation error.
+// This preserves the pre-move wire format so mixed-version deploys stay
+// compatible.
+func (t TaskStartRequest) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Task)
+}
+
+// UnmarshalJSON accepts the flat wire format described above.
+func (t *TaskStartRequest) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &t.Task)
 }
 
 func (t *TaskStartRequest) Validate() error {

--- a/models/auctioneer_types_test.go
+++ b/models/auctioneer_types_test.go
@@ -1,0 +1,70 @@
+package models_test
+
+import (
+	"encoding/json"
+
+	"code.cloudfoundry.org/bbs/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TaskStartRequest", func() {
+	var request models.TaskStartRequest
+
+	BeforeEach(func() {
+		request = models.NewTaskStartRequest(models.NewSchedulingTask(
+			"task-guid-123",
+			"my-domain",
+			models.NewResource(256, 1024, 0),
+			models.NewPlacementConstraint("cflinuxfs4", []string{"tag"}, []string{"driver"}),
+		))
+	})
+
+	Describe("MarshalJSON", func() {
+		It("flattens the wrapped SchedulingTask to the top level, instead of nesting it under a \"Task\" key", func() {
+			wire, err := json.Marshal(request)
+			Expect(err).NotTo(HaveOccurred())
+
+			var flat map[string]interface{}
+			Expect(json.Unmarshal(wire, &flat)).To(Succeed())
+
+			Expect(flat).NotTo(HaveKey("Task"))
+			Expect(flat["TaskGuid"]).To(Equal("task-guid-123"))
+			Expect(flat["Domain"]).To(Equal("my-domain"))
+			Expect(flat["RootFs"]).To(Equal("cflinuxfs4"))
+			Expect(flat["MemoryMB"]).To(Equal(float64(256)))
+			Expect(flat["DiskMB"]).To(Equal(float64(1024)))
+		})
+	})
+
+	Describe("UnmarshalJSON", func() {
+		It("round-trips through its own MarshalJSON", func() {
+			wire, err := json.Marshal(request)
+			Expect(err).NotTo(HaveOccurred())
+
+			var roundTripped models.TaskStartRequest
+			Expect(json.Unmarshal(wire, &roundTripped)).To(Succeed())
+			Expect(roundTripped).To(Equal(request))
+		})
+
+		It("accepts the flat, pre-move wire format produced by an old auctioneer client", func() {
+			flatWire := []byte(`{
+				"TaskGuid": "task-guid-123",
+				"Domain": "my-domain",
+				"RootFs": "cflinuxfs4",
+				"PlacementTags": ["tag"],
+				"VolumeDrivers": ["driver"],
+				"MemoryMB": 256,
+				"DiskMB": 1024,
+				"MaxPids": 0,
+				"state": "Invalid",
+				"failed": false
+			}`)
+
+			var parsed models.TaskStartRequest
+			Expect(json.Unmarshal(flatWire, &parsed)).To(Succeed())
+			Expect(parsed).To(Equal(request))
+			Expect(parsed.Validate()).NotTo(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
8b9ea83 (in diego-release) moved TaskStartRequest out of the auctioneer package and into bbs/models as part of breaking the bbs<->auctioneer import cycle. The old type anonymously embedded rep.Task, so its fields were promoted to the top level of the JSON object on the wire. The new type wraps the equivalent SchedulingTask in a named `Task` field instead, which nests the payload one level deeper under a "Task" key.

That silently breaks auctions during a rolling deploy: an old auctioneer unmarshaling a new BBS's payload (or vice versa) finds no top-level fields, json.Unmarshal returns a nil error with everything zero-valued, Validate() fails with "task guid is empty", and the request is dropped -- but the handler still returns 202 Accepted, so BBS never sees an error.

LRPStartRequest doesn't have this problem: it already matches the old auctioneer.LRPStartRequest field-for-field, including the anonymous embeds of PlacementConstraint/Resource.

Add MarshalJSON/UnmarshalJSON on TaskStartRequest to flatten to/from the wrapped SchedulingTask, restoring the pre-move wire shape. This keeps the current Go-level API (the `Task` field, `.Task.TaskGuid` accessors used by controllers/task_controller.go and elsewhere) intact -- only the JSON encoding changes -- so mixed-version BBS/auctioneer deploys stay compatible without any call-site changes.

[ai-assisted=yes]


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
