### PR TITLE
fix: restore flat JSON wire format for TaskStartRequest

### DIFF
--- a/models/auctioneer_types.go
+++ b/models/auctioneer_types.go
@@ -4,6 +4,7 @@ package models
 // to break the bbs <-> auctioneer module cycle.
 
 import (
+	"encoding/json"
 	"errors"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -20,6 +21,20 @@ type AuctioneerClient interface {
 
 type TaskStartRequest struct {
 	Task SchedulingTask
+}
+
+// MarshalJSON serialises TaskStartRequest as a flat object (the fields of Task
+// promoted to the top level) so that the JSON wire format is identical to the
+// pre-8b9ea83 auctioneer.TaskStartRequest{rep.Task} shape.  This keeps BBS
+// and auctioneer wire-compatible across rolling deploys.
+func (t TaskStartRequest) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Task)
+}
+
+// UnmarshalJSON is the inverse of MarshalJSON: it reads the flat wire format
+// and populates the nested Task field.
+func (t *TaskStartRequest) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &t.Task)
 }
 
 func NewTaskStartRequest(task SchedulingTask) TaskStartRequest {

--- a/models/auctioneer_types_test.go
+++ b/models/auctioneer_types_test.go
@@ -1,0 +1,57 @@
+package models_test
+
+import (
+	"encoding/json"
+
+	"code.cloudfoundry.org/bbs/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TaskStartRequest", func() {
+	Describe("JSON wire format", func() {
+		var task models.SchedulingTask
+
+		BeforeEach(func() {
+			task = models.NewSchedulingTask(
+				"task-guid-1",
+				"cf-tasks",
+				models.NewResource(256, 1024, 0),
+				models.NewPlacementConstraint("cflinuxfs4", nil, nil),
+			)
+		})
+
+		It("marshals as a flat object, not nested under a \"Task\" key", func() {
+			req := models.NewTaskStartRequest(task)
+
+			payload, err := json.Marshal(req)
+			Expect(err).NotTo(HaveOccurred())
+
+			var raw map[string]interface{}
+			Expect(json.Unmarshal(payload, &raw)).To(Succeed())
+
+			Expect(raw).To(HaveKeyWithValue("TaskGuid", "task-guid-1"))
+			Expect(raw).NotTo(HaveKey("Task"))
+		})
+
+		It("round-trips through the flat wire format", func() {
+			req := models.NewTaskStartRequest(task)
+			payload, err := json.Marshal(req)
+			Expect(err).NotTo(HaveOccurred())
+
+			var decoded models.TaskStartRequest
+			Expect(json.Unmarshal(payload, &decoded)).To(Succeed())
+			Expect(decoded.Task.TaskGuid).To(Equal("task-guid-1"))
+			Expect(decoded.Validate()).To(Succeed())
+		})
+
+		It("decodes the legacy pre-8b9ea83 flat auctioneer wire format", func() {
+			legacyPayload := []byte(`{"TaskGuid":"task-guid-1","Domain":"cf-tasks","RootFs":"cflinuxfs4","MemoryMB":256,"DiskMB":1024,"MaxPids":0}`)
+
+			var decoded models.TaskStartRequest
+			Expect(json.Unmarshal(legacyPayload, &decoded)).To(Succeed())
+			Expect(decoded.Task.TaskGuid).To(Equal("task-guid-1"))
+			Expect(decoded.Validate()).To(Succeed())
+		})
+	})
+})

--- a/vendor/code.cloudfoundry.org/bbs/models/auctioneer_types.go
+++ b/vendor/code.cloudfoundry.org/bbs/models/auctioneer_types.go
@@ -4,6 +4,7 @@ package models
 // to break the bbs <-> auctioneer module cycle.
 
 import (
+	"encoding/json"
 	"errors"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -20,6 +21,20 @@ type AuctioneerClient interface {
 
 type TaskStartRequest struct {
 	Task SchedulingTask
+}
+
+// MarshalJSON serialises TaskStartRequest as a flat object (the fields of Task
+// promoted to the top level) so that the JSON wire format is identical to the
+// pre-8b9ea83 auctioneer.TaskStartRequest{rep.Task} shape.  This keeps BBS
+// and auctioneer wire-compatible across rolling deploys.
+func (t TaskStartRequest) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Task)
+}
+
+// UnmarshalJSON is the inverse of MarshalJSON: it reads the flat wire format
+// and populates the nested Task field.
+func (t *TaskStartRequest) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &t.Task)
 }
 
 func NewTaskStartRequest(task SchedulingTask) TaskStartRequest {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The named field Task SchedulingTask introduced in 8b9ea83 changed the JSON encoding from a flat object to {"Task":{...}}, breaking backward compatibility between BBS and auctioneer during rolling deploys.  An old auctioneer receiving the nested format would silently drop tasks: json.Unmarshal succeeds with zero values, Validate() fails with "task guid is empty", and the handler still returns 202 Accepted.

Add MarshalJSON/UnmarshalJSON to TaskStartRequest that delegate directly to the embedded SchedulingTask, producing the same flat wire shape that the pre-8b9ea83 auctioneer.TaskStartRequest{rep.Task} anonymous-embed generated.  The struct field Task SchedulingTask is unchanged, so all existing callers compile without modification.


Backward Compatibility
---------------
Breaking Change? **No**

