### PR TITLE
Fix linting errors

### DIFF
--- a/controllers/actual_lrp_lifecycle_controller.go
+++ b/controllers/actual_lrp_lifecycle_controller.go
@@ -68,6 +68,7 @@ func lookupLRPInSlice(lrps []*models.ActualLRP, key *models.ActualLRPInstanceKey
 
 func (h *ActualLRPLifecycleController) ClaimActualLRP(ctx context.Context, logger lager.Logger, processGUID string, index int32, actualLRPInstanceKey *models.ActualLRPInstanceKey) error {
 	eventCalculator := calculator.ActualLRPEventCalculator{
+		//lint:ignore SA1019 - still need to emit these events until the ActualLRPGroup api is deleted
 		ActualLRPGroupHub:    h.actualHub,
 		ActualLRPInstanceHub: h.actualLRPInstanceHub,
 	}
@@ -110,6 +111,7 @@ func (h *ActualLRPLifecycleController) StartActualLRP(ctx context.Context,
 	availabilityZone string,
 ) error {
 	eventCalculator := calculator.ActualLRPEventCalculator{
+		//lint:ignore SA1019 - still need to emit these events until the ActualLRPGroup api is deleted
 		ActualLRPGroupHub:    h.actualHub,
 		ActualLRPInstanceHub: h.actualLRPInstanceHub,
 	}
@@ -176,6 +178,7 @@ func (h *ActualLRPLifecycleController) CrashActualLRP(ctx context.Context, logge
 	}
 
 	eventCalculator := calculator.ActualLRPEventCalculator{
+		//lint:ignore SA1019 - still need to emit these events until the ActualLRPGroup api is deleted
 		ActualLRPGroupHub:    h.actualHub,
 		ActualLRPInstanceHub: h.actualLRPInstanceHub,
 	}
@@ -235,6 +238,7 @@ func (h *ActualLRPLifecycleController) FailActualLRP(ctx context.Context, logger
 	}
 
 	eventCalculator := calculator.ActualLRPEventCalculator{
+		//lint:ignore SA1019 - still need to emit these events until the ActualLRPGroup api is deleted
 		ActualLRPGroupHub:    h.actualHub,
 		ActualLRPInstanceHub: h.actualLRPInstanceHub,
 	}
@@ -262,6 +266,7 @@ func (h *ActualLRPLifecycleController) RemoveActualLRP(ctx context.Context, logg
 	}
 
 	eventCalculator := calculator.ActualLRPEventCalculator{
+		//lint:ignore SA1019 - still need to emit these events until the ActualLRPGroup api is deleted
 		ActualLRPGroupHub:    h.actualHub,
 		ActualLRPInstanceHub: h.actualLRPInstanceHub,
 	}
@@ -284,6 +289,7 @@ func (h *ActualLRPLifecycleController) RetireActualLRP(ctx context.Context, logg
 	}
 
 	eventCalculator := calculator.ActualLRPEventCalculator{
+		//lint:ignore SA1019 - still need to emit these events until the ActualLRPGroup api is deleted
 		ActualLRPGroupHub:    h.actualHub,
 		ActualLRPInstanceHub: h.actualLRPInstanceHub,
 	}

--- a/controllers/evacuation_controller.go
+++ b/controllers/evacuation_controller.go
@@ -48,6 +48,7 @@ func (h *EvacuationController) RemoveEvacuatingActualLRP(ctx context.Context, lo
 	}
 
 	eventCalculator := calculator.ActualLRPEventCalculator{
+		//lint:ignore SA1019 - still need to emit these events until the ActualLRPGroup api is deleted
 		ActualLRPGroupHub:    h.actualHub,
 		ActualLRPInstanceHub: h.actualLRPInstanceHub,
 	}
@@ -137,6 +138,7 @@ func (h *EvacuationController) removeEvacuatingOrSuspect(
 
 func (h *EvacuationController) EvacuateClaimedActualLRP(ctx context.Context, logger lager.Logger, actualLRPKey *models.ActualLRPKey, actualLRPInstanceKey *models.ActualLRPInstanceKey) (bool, error) {
 	eventCalculator := calculator.ActualLRPEventCalculator{
+		//lint:ignore SA1019 - still need to emit these events until the ActualLRPGroup api is deleted
 		ActualLRPGroupHub:    h.actualHub,
 		ActualLRPInstanceHub: h.actualLRPInstanceHub,
 	}
@@ -184,6 +186,7 @@ func (h *EvacuationController) EvacuateClaimedActualLRP(ctx context.Context, log
 
 func (h *EvacuationController) EvacuateCrashedActualLRP(ctx context.Context, logger lager.Logger, actualLRPKey *models.ActualLRPKey, actualLRPInstanceKey *models.ActualLRPInstanceKey, errorMessage string) error {
 	eventCalculator := calculator.ActualLRPEventCalculator{
+		//lint:ignore SA1019 - still need to emit these events until the ActualLRPGroup api is deleted
 		ActualLRPGroupHub:    h.actualHub,
 		ActualLRPInstanceHub: h.actualLRPInstanceHub,
 	}
@@ -250,6 +253,7 @@ func (h *EvacuationController) EvacuateRunningActualLRP(
 	availabilityZone string,
 ) (bool, error) {
 	eventCalculator := calculator.ActualLRPEventCalculator{
+		//lint:ignore SA1019 - still need to emit these events until the ActualLRPGroup api is deleted
 		ActualLRPGroupHub:    h.actualHub,
 		ActualLRPInstanceHub: h.actualLRPInstanceHub,
 	}
@@ -404,6 +408,7 @@ func (h *EvacuationController) EvacuateRunningActualLRP(
 
 func (h *EvacuationController) EvacuateStoppedActualLRP(ctx context.Context, logger lager.Logger, actualLRPKey *models.ActualLRPKey, actualLRPInstanceKey *models.ActualLRPInstanceKey) error {
 	eventCalculator := calculator.ActualLRPEventCalculator{
+		//lint:ignore SA1019 - still need to emit these events until the ActualLRPGroup api is deleted
 		ActualLRPGroupHub:    h.actualHub,
 		ActualLRPInstanceHub: h.actualLRPInstanceHub,
 	}
@@ -462,6 +467,7 @@ func (h *EvacuationController) requestAuction(ctx context.Context, logger lager.
 func (h *EvacuationController) evacuateInstance(ctx context.Context, logger lager.Logger, allLRPs []*models.ActualLRP, actualLRP *models.ActualLRP) error {
 
 	eventCalculator := calculator.ActualLRPEventCalculator{
+		//lint:ignore SA1019 - still need to emit these events until the ActualLRPGroup api is deleted
 		ActualLRPGroupHub:    h.actualHub,
 		ActualLRPInstanceHub: h.actualLRPInstanceHub,
 	}

--- a/handlers/desired_lrp_handlers.go
+++ b/handlers/desired_lrp_handlers.go
@@ -359,6 +359,7 @@ func (h *DesiredLRPHandler) createUnclaimedActualLRPs(ctx context.Context, logge
 	createdIndicesChan := make(chan int, count)
 
 	eventCalculator := calculator.ActualLRPEventCalculator{
+		//lint:ignore SA1019 - still need to emit these events until the ActualLRPGroup api is deleted
 		ActualLRPGroupHub:    h.actualHub,
 		ActualLRPInstanceHub: h.actualLRPInstanceHub,
 	}


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fixes linting errors:
controllers/actual_lrp_lifecycle_controller.go:71:3: (code.cloudfoundry.org/bbs/events/calculator.ActualLRPEventCalculator).ActualLRPGroupHub is deprecated: use ActualLRPInstanceHub instead  (SA1019)

[ai-assisted=yes]

Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
