### PR TITLE
fix: pin ifrit to v0.0.0-20260418191334-846868129986 (JIRA-1234)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,3 +60,8 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+replace (
+	// pin ifrit until https://github.com/tedsuo/ifrit/pull/48 is merged
+	github.com/tedsuo/ifrit => github.com/tedsuo/ifrit v0.0.0-20260418191334-846868129986
+)


### PR DESCRIPTION
## Summary

- Pins `github.com/tedsuo/ifrit` to `v0.0.0-20260418191334-846868129986` via a `replace` directive
- Prevents transitive upgrade to the newer pseudoversion while https://github.com/tedsuo/ifrit/pull/48 remains unmerged
- Matches the pattern already in place in `garden-runc-release`

Ticket: JIRA-1234

🤖 Generated with Claude Code